### PR TITLE
Add missing toggle for maximum time to play

### DIFF
--- a/lib/homepage.dart
+++ b/lib/homepage.dart
@@ -289,6 +289,9 @@ class HomePage extends StatelessWidget with GameConfig, AppPage {
                       model.settings
                           .setting(Settings.filterMinimumTimeToPlay.name)
                           .enabled = value;
+                      model.settings
+                          .setting(Settings.filterMaximumTimeToPlay.name)
+                          .enabled = value;
                       model.updateStore();
                       model.invalidateCache();
                     },


### PR DESCRIPTION
Closes how-many-meeple/how-many-meeples#70 
Need to instruct users to toggle off and on the time filter to fix the issue