### PR TITLE
feat: add Finish button to guided flow for direct navigation to results

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ generate_web:
 	flutter build web
 
 upload_web:
-	aws s3 cp ./build/web s3://www.howmanymeeple.com --recursive
+	aws s3 cp ./build/web s3://www.howmanymeeple.com --recursive --exclude "config.local.json" --profile howmanymeeple
 
 clean:
 	flutter clean

--- a/lib/guided_flow_homepage.dart
+++ b/lib/guided_flow_homepage.dart
@@ -266,6 +266,18 @@ class _GuidedFlowHomePageState extends State<GuidedFlowHomePage> {
                   icon: const Icon(Icons.arrow_forward),
                   label: const Text('Next'),
                 ),
+
+                // Finish button — skip straight to results
+                if (_currentStep < _totalSteps - 1) ...[
+                  const SizedBox(width: 8),
+                  FilledButton.icon(
+                    onPressed: canProceedFromStep1
+                        ? () => setState(() => _currentStep = _totalSteps - 1)
+                        : null,
+                    icon: const Icon(Icons.check),
+                    label: const Text('Finish'),
+                  ),
+                ],
               ],
             ),
           ],

--- a/lib/platform/web_or_tablet/web_version_info.dart
+++ b/lib/platform/web_or_tablet/web_version_info.dart
@@ -1,4 +1,4 @@
 class WebVersionInfo {
-  static const String name = '2.0.0';
+  static const String name = '2.0.2';
   static const int build = 2100;
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: how_many_mobile_meeple
 description:  A flutter/dart project for picking board games
-version: 2.0.0+1
+version: 2.0.2+3
 
 environment:
   sdk: '>=3.0.0 <4.0.0'


### PR DESCRIPTION
Adds a Finish button alongside Next on all guided flow steps, allowing users to skip straight to the results phase without stepping through each filter. Disabled on step 1 until a source is selected. Also fixes Makefile deploy to use correct AWS profile and exclude config.local.json.

Bump version to 2.0.2.