### PR TITLE
feat: swipe gestures, larger step hit targets, full-width advanced mode

### DIFF
--- a/lib/guided_flow/advanced_mode_widget.dart
+++ b/lib/guided_flow/advanced_mode_widget.dart
@@ -7,72 +7,28 @@ import 'package:how_many_mobile_meeple/components/player_filter_widget.dart';
 import 'package:how_many_mobile_meeple/components/rating_filter_widget.dart';
 import 'package:how_many_mobile_meeple/components/time_filter_widget.dart';
 
-/// Advanced Mode Widget
-/// Wraps the existing full-control homepage UI in an expandable panel
 class AdvancedModeWidget extends StatelessWidget {
   const AdvancedModeWidget({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return Card(
-      elevation: 2,
-      child: ExpansionTile(
-        title: Row(
-          children: [
-            Icon(
-              Icons.tune,
-              color: Theme.of(context).colorScheme.primary,
-            ),
-            const SizedBox(width: 12),
-            Text(
-              'Advanced Options',
-              style: Theme.of(context).textTheme.titleLarge?.copyWith(
-                    fontWeight: FontWeight.bold,
-                  ),
-            ),
-          ],
-        ),
-        subtitle: const Padding(
-          padding: EdgeInsets.only(top: 4),
-          child: Text('Full control over all filters'),
-        ),
-        initiallyExpanded: true,
-        children: const [
-          Padding(
-            padding: EdgeInsets.all(16.0),
-            child: Column(
-              children: [
-                // Username/Geeklist input
-                BoardGameItemInputWidget(),
-                SizedBox(height: 8),
-
-                // Board Game Geek Item Display
-                BoardGameItemListWidget(),
-                SizedBox(height: 8),
-
-                // Time slider
-                TimeFilterWidget(),
-                SizedBox(height: 8),
-
-                // Player count slider
-                PlayerFilterWidget(),
-                SizedBox(height: 8),
-
-                // Complexity slider
-                ComplexityFilterWidget(),
-                SizedBox(height: 8),
-
-                // Rating slider
-                RatingFilterWidget(),
-                SizedBox(height: 8),
-
-                // Mechanics filter
-                MechanicFilterWidget(),
-              ],
-            ),
-          ),
-        ],
-      ),
+    return const Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        BoardGameItemInputWidget(),
+        SizedBox(height: 8),
+        BoardGameItemListWidget(),
+        SizedBox(height: 8),
+        TimeFilterWidget(),
+        SizedBox(height: 8),
+        PlayerFilterWidget(),
+        SizedBox(height: 8),
+        ComplexityFilterWidget(),
+        SizedBox(height: 8),
+        RatingFilterWidget(),
+        SizedBox(height: 8),
+        MechanicFilterWidget(),
+      ],
     );
   }
 }

--- a/lib/guided_flow_homepage.dart
+++ b/lib/guided_flow_homepage.dart
@@ -78,24 +78,37 @@ class _GuidedFlowHomePageState extends State<GuidedFlowHomePage> {
 
   /// Builds the guided flow with step progression
   Widget _buildGuidedFlow(BuildContext context) {
-    return SingleChildScrollView(
-      child: Padding(
-        padding: const EdgeInsets.all(16.0),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            // Progress indicator
-            _buildProgressIndicator(),
-            const SizedBox(height: 24),
+    return GestureDetector(
+      onHorizontalDragEnd: (details) {
+        final velocity = details.primaryVelocity ?? 0;
+        final model = AppModel.of(context, listen: false);
+        if (velocity < -300 && _currentStep < _totalSteps - 1) {
+          final canProceed =
+              _currentStep != 0 || model.items.itemList.isNotEmpty;
+          if (canProceed) setState(() => _currentStep++);
+        } else if (velocity > 300 && _currentStep > 0) {
+          setState(() => _currentStep--);
+        }
+      },
+      child: SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              // Progress indicator
+              _buildProgressIndicator(),
+              const SizedBox(height: 24),
 
-            // Current step content
-            _buildCurrentStep(),
+              // Current step content
+              _buildCurrentStep(),
 
-            const SizedBox(height: 24),
+              const SizedBox(height: 24),
 
-            // Navigation buttons (for steps 0-3)
-            if (_currentStep < _totalSteps - 1) _buildStepNavigation(),
-          ],
+              // Navigation buttons (for steps 0-3)
+              if (_currentStep < _totalSteps - 1) _buildStepNavigation(),
+            ],
+          ),
         ),
       ),
     );
@@ -128,30 +141,34 @@ class _GuidedFlowHomePageState extends State<GuidedFlowHomePage> {
                     onTap: isAccessible
                         ? () => setState(() => _currentStep = index)
                         : null,
-                    child: Container(
-                      height: 8,
-                      margin: EdgeInsets.only(
-                          right: index < _totalSteps - 1 ? 4 : 0),
-                      decoration: BoxDecoration(
-                        color: isCompleted || isActive
-                            ? Theme.of(context).colorScheme.primary
-                            : Theme.of(context)
-                                .colorScheme
-                                .surfaceContainerHighest,
-                        borderRadius: BorderRadius.circular(4),
-                      ),
-                      child: isActive
-                          ? Container(
-                              decoration: BoxDecoration(
-                                border: Border.all(
-                                  color:
-                                      Theme.of(context).colorScheme.onPrimary,
-                                  width: 2,
+                    behavior: HitTestBehavior.opaque,
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(vertical: 10),
+                      child: Container(
+                        height: 8,
+                        margin: EdgeInsets.only(
+                            right: index < _totalSteps - 1 ? 4 : 0),
+                        decoration: BoxDecoration(
+                          color: isCompleted || isActive
+                              ? Theme.of(context).colorScheme.primary
+                              : Theme.of(context)
+                                  .colorScheme
+                                  .surfaceContainerHighest,
+                          borderRadius: BorderRadius.circular(4),
+                        ),
+                        child: isActive
+                            ? Container(
+                                decoration: BoxDecoration(
+                                  border: Border.all(
+                                    color:
+                                        Theme.of(context).colorScheme.onPrimary,
+                                    width: 2,
+                                  ),
+                                  borderRadius: BorderRadius.circular(4),
                                 ),
-                                borderRadius: BorderRadius.circular(4),
-                              ),
-                            )
-                          : null,
+                              )
+                            : null,
+                      ),
                     ),
                   ),
                 );
@@ -184,7 +201,7 @@ class _GuidedFlowHomePageState extends State<GuidedFlowHomePage> {
       onTap:
           isAccessible ? () => setState(() => _currentStep = stepIndex) : null,
       child: Padding(
-        padding: const EdgeInsets.symmetric(vertical: 4, horizontal: 2),
+        padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 8),
         child: Text(
           label,
           style: Theme.of(context).textTheme.bodySmall?.copyWith(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: how_many_mobile_meeple
 description:  A flutter/dart project for picking board games
-version: 2.1.0+5
+version: 2.2.0+6
 
 environment:
   sdk: '>=3.0.0 <4.0.0'


### PR DESCRIPTION
Closes #40 
- Swipe left/right on the guided flow to navigate between steps, with the same step-1 guard (items required before proceeding) as the Next button
- Progress bar segments and step labels have larger touch targets for easier tapping on mobile
- Advanced mode panel renders full-width without the Card/ExpansionTile wrapper, giving filters maximum available space