### PR TITLE
feat: add Board Game News link to app bar

### DIFF
--- a/lib/how_many_meeple_app_bar.dart
+++ b/lib/how_many_meeple_app_bar.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:how_many_mobile_meeple/platform/pages.dart';
 import 'package:how_many_mobile_meeple/save_dialog.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 import 'app_common.dart';
 import 'components/empty_widget.dart';
@@ -38,17 +39,29 @@ class HowManyMeepleAppBar extends AppBar {
                   ),
                 ],
               ),
-              hasSaveDialog
-                  ? IconButton(
-                      icon: Icon(Icons.save),
-                      onPressed: model != null
-                          ? () => showDialog(
-                              context: context,
-                              builder: (context) => SaveDialog(
-                                    model: model,
-                                  ))
-                          : null)
-                  : EmptyWidget()
+              Row(
+                children: <Widget>[
+                  IconButton(
+                    icon: Icon(Icons.newspaper),
+                    tooltip: 'Board Game News',
+                    onPressed: () => launchUrl(
+                      Uri.parse('https://www.boardgamenews.co.uk/'),
+                      mode: LaunchMode.externalApplication,
+                    ),
+                  ),
+                  hasSaveDialog
+                      ? IconButton(
+                          icon: Icon(Icons.save),
+                          onPressed: model != null
+                              ? () => showDialog(
+                                  context: context,
+                                  builder: (context) => SaveDialog(
+                                        model: model,
+                                      ))
+                              : null)
+                      : EmptyWidget(),
+                ],
+              ),
             ],
           ),
         );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: how_many_mobile_meeple
 description:  A flutter/dart project for picking board games
-version: 2.2.0+6
+version: 2.2.1+7
 
 environment:
   sdk: '>=3.0.0 <4.0.0'


### PR DESCRIPTION
Adds a newspaper icon button to the top nav bar, left of the save button, linking to boardgamenews.co.uk in an external browser. Bumps to v2.2.1+7.