### PR TITLE
chore: fix advanced mode flicker and stabilise network cache fetch

### DIFF
--- a/lib/guided_flow_homepage.dart
+++ b/lib/guided_flow_homepage.dart
@@ -27,12 +27,16 @@ class GuidedFlowHomePage extends StatefulWidget with AppPage {
 
 class _GuidedFlowHomePageState extends State<GuidedFlowHomePage> {
   int _currentStep = 0;
+  bool _showAdvancedMode = false;
 
   final int _totalSteps = 5;
 
-  bool _getPreferAdvancedMode(AppModel model) {
-    final setting = model.settings.setting('preferAdvancedMode');
-    return setting.getBool();
+  void _syncAdvancedMode(AppModel model) {
+    final value = model.settings.setting('preferAdvancedMode').getBool();
+    if (value != _showAdvancedMode) {
+      WidgetsBinding.instance.addPostFrameCallback(
+          (_) => setState(() => _showAdvancedMode = value));
+    }
   }
 
   @override
@@ -44,8 +48,7 @@ class _GuidedFlowHomePageState extends State<GuidedFlowHomePage> {
           model.refreshFromUrl();
         }
 
-        // Use the setting as the single source of truth
-        final showAdvancedMode = _getPreferAdvancedMode(model);
+        _syncAdvancedMode(model);
 
         return Scaffold(
           appBar: HowManyMeepleAppBar(
@@ -60,7 +63,7 @@ class _GuidedFlowHomePageState extends State<GuidedFlowHomePage> {
             children: [
               const PwaInstallBanner(),
               Expanded(
-                child: showAdvancedMode
+                child: _showAdvancedMode
                     ? _buildAdvancedMode(context)
                     : _buildGuidedFlow(context),
               ),
@@ -68,7 +71,7 @@ class _GuidedFlowHomePageState extends State<GuidedFlowHomePage> {
           ),
           bottomNavigationBar: _buildFooter(context),
           persistentFooterButtons:
-              !showAdvancedMode && _currentStep == _totalSteps - 1
+              !_showAdvancedMode && _currentStep == _totalSteps - 1
                   ? [widget.iconButtonGroup(context)]
                   : null,
         );

--- a/lib/network_content_widget.dart
+++ b/lib/network_content_widget.dart
@@ -22,7 +22,6 @@ abstract class NetworkWidget extends StatelessWidget with ScreenTools {
   static const String findingGames = "Finding games to play";
 
   Widget pageErrors(BuildContext context, String error) {
-    // Constrain icon to reasonable size (max 200px or 50% of screen width, whichever is smaller)
     final iconSize = getScreenWidthPercentageInPixels(
             context, ScreenTools.fiftyPercentScreen)
         .clamp(0.0, 200.0);
@@ -50,7 +49,6 @@ abstract class NetworkWidget extends StatelessWidget with ScreenTools {
   }
 
   Widget loadingSpinner(BuildContext context) {
-    // Constrain spinner to reasonable size (max 200px or 50% of screen width, whichever is smaller)
     final spinnerSize = getScreenWidthPercentageInPixels(
             context, ScreenTools.fiftyPercentScreen)
         .clamp(0.0, 200.0);
@@ -74,43 +72,101 @@ abstract class NetworkWidget extends StatelessWidget with ScreenTools {
     );
   }
 
-  Widget gameDataResponse(
-      AppModel model,
-      AsyncSnapshot<Games> snapshot,
-      BuildContext context,
-      Widget displayWidgetFn(BuildContext context, AppModel model)) {
-    if (snapshot.data!.games.isEmpty) {
-      return pageErrors(context, pageErrorNoGamesAvailable);
-    }
-    model.replaceCache(snapshot.data!);
-    return displayWidgetFn(context, model);
-  }
-
   Widget loadNetworkContent(
       Widget displayWidgetFn(BuildContext context, AppModel model)) {
     return Consumer<AppModel>(builder: (context, model, child) {
       if (model.items.isEmpty) {
         return pageErrors(context, pageErrorNoItemsSupplied);
       }
-      return contentFromNetworkOrCache(context, model, displayWidgetFn);
+      return _GameFetcher(
+        model: model,
+        pageErrors: pageErrors,
+        loadingSpinner: loadingSpinner,
+        pageFrameOutline: pageFrameOutline,
+        displayWidgetFn: displayWidgetFn,
+      );
     });
   }
+}
 
-  Widget contentFromNetworkOrCache(BuildContext context, AppModel model,
-      Widget displayWidgetFn(BuildContext context, AppModel model)) {
-    if (!model.bggCache.isStale()) {
-      return displayWidgetFn(context, model);
+/// Stateful widget that owns the fetch Future so that model notifications
+/// (notifyListeners) do not abandon an in-flight request and restart it.
+/// A new fetch is only started when the cache transitions to stale AND
+/// no fetch is already in progress.
+class _GameFetcher extends StatefulWidget {
+  final AppModel model;
+  final Widget Function(BuildContext, String) pageErrors;
+  final Widget Function(BuildContext) loadingSpinner;
+  final Widget Function(BuildContext, Widget) pageFrameOutline;
+  final Widget Function(BuildContext, AppModel) displayWidgetFn;
+
+  const _GameFetcher({
+    required this.model,
+    required this.pageErrors,
+    required this.loadingSpinner,
+    required this.pageFrameOutline,
+    required this.displayWidgetFn,
+  });
+
+  @override
+  State<_GameFetcher> createState() => _GameFetcherState();
+}
+
+class _GameFetcherState extends State<_GameFetcher> {
+  Future<Games>? _future;
+  bool _fetching = false;
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.model.bggCache.isStale()) {
+      _startFetch();
+    }
+  }
+
+  @override
+  void didUpdateWidget(_GameFetcher old) {
+    super.didUpdateWidget(old);
+    // Only start a new fetch when the cache has become stale and no fetch is running.
+    if (widget.model.bggCache.isStale() && !_fetching) {
+      setState(_startFetch);
+    }
+  }
+
+  void _startFetch() {
+    _fetching = true;
+    _future = LoadGames.fetchGames(
+        widget.model.settings, widget.model.items.itemList);
+    _future!.then(
+      (_) {
+        if (mounted) setState(() => _fetching = false);
+      },
+      onError: (_) {
+        if (mounted) setState(() => _fetching = false);
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!widget.model.bggCache.isStale()) {
+      return widget.displayWidgetFn(context, widget.model);
     }
     return FutureBuilder<Games>(
-      future: LoadGames.fetchGames(model.settings, model.items.itemList),
+      future: _future,
       builder: (context, snapshot) {
         if (snapshot.hasData) {
-          return gameDataResponse(model, snapshot, context, displayWidgetFn);
+          if (snapshot.data!.games.isEmpty) {
+            return widget.pageErrors(
+                context, NetworkWidget.pageErrorNoGamesAvailable);
+          }
+          widget.model.replaceCache(snapshot.data!);
+          return widget.displayWidgetFn(context, widget.model);
         } else if (snapshot.hasError) {
-          return pageErrors(context, pageErrorOneOrMoreItemsInvalid);
+          return widget.pageErrors(
+              context, NetworkWidget.pageErrorOneOrMoreItemsInvalid);
         }
-        // By default, show a loading spinner.
-        return pageFrameOutline(context, loadingSpinner(context));
+        return widget.pageFrameOutline(context, widget.loadingSpinner(context));
       },
     );
   }

--- a/test/guided_flow/guided_flow_homepage_test.dart
+++ b/test/guided_flow/guided_flow_homepage_test.dart
@@ -1,0 +1,89 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:how_many_mobile_meeple/guided_flow_homepage.dart';
+import 'package:how_many_mobile_meeple/model/model.dart';
+import 'package:how_many_mobile_meeple/model/settings.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+Widget _buildTestApp(AppModel model) {
+  return MaterialApp(
+    home: ChangeNotifierProvider.value(
+      value: model,
+      child: GuidedFlowHomePage(),
+    ),
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  group('GuidedFlowHomePage advanced mode stability', () {
+    testWidgets(
+        'stays in advanced mode when model notifies listeners after switching',
+        (WidgetTester tester) async {
+      final model = AppModel();
+
+      // Pre-set advanced mode before the widget loads so loadStoredData picks
+      // it up without triggering async network calls
+      final setting = model.settings.setting(Settings.preferAdvancedMode.name);
+      setting.value = true;
+      setting.enabled = true;
+      model.settings.updateSetting(setting);
+      model.hasLoadedPersistedData = true;
+
+      await tester.pumpWidget(_buildTestApp(model));
+      await tester.pump(const Duration(milliseconds: 100));
+
+      // Guided flow step indicator must not be present in advanced mode
+      expect(find.text('Step 1 of 5'), findsNothing);
+
+      // Simulate a model notification (e.g. a filter widget updating state)
+      model.refreshState();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      // Must still be in advanced mode — not flipped back to guided flow
+      expect(find.text('Step 1 of 5'), findsNothing);
+    });
+
+    testWidgets('shows guided flow by default', (WidgetTester tester) async {
+      final model = AppModel();
+      model.hasLoadedPersistedData = true;
+
+      await tester.pumpWidget(_buildTestApp(model));
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(find.text('Step 1 of 5'), findsOneWidget);
+    });
+
+    testWidgets('switches back to guided flow when preference is cleared',
+        (WidgetTester tester) async {
+      final model = AppModel();
+      model.hasLoadedPersistedData = true;
+
+      final setting = model.settings.setting(Settings.preferAdvancedMode.name);
+      setting.value = true;
+      setting.enabled = true;
+      model.settings.updateSetting(setting);
+
+      await tester.pumpWidget(_buildTestApp(model));
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(find.text('Step 1 of 5'), findsNothing);
+
+      // Disable advanced mode
+      setting.value = false;
+      model.settings.updateSetting(setting);
+      model.refreshState();
+      // Two pumps: one for the Consumer rebuild, one for the postFrameCallback
+      await tester.pump(const Duration(milliseconds: 100));
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(find.text('Step 1 of 5'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
Advanced mode was flickering back to guided flow on any model notification because showAdvancedMode was re-derived from model state on every Consumer rebuild. Fixed by caching mode in _showAdvancedMode state field and applying changes via addPostFrameCallback.

Network content widget previously created a new Future on every model notification, causing in-flight fetches to be abandoned and restarted. Replaced the stateless FutureBuilder pattern with a StatefulWidget (_GameFetcher) that owns the Future across rebuilds and only starts a new fetch when the cache becomes stale and no fetch is already running.

Added widget tests for advanced mode stability to prevent regression.