### PR TITLE
chore: auto-tag releases and notify PWA of new versions

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,98 @@
+name: Tag Release
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Determine version bump
+        id: bump
+        run: |
+          MSG=$(git log -1 --pretty=%s)
+          echo "Commit: $MSG"
+
+          # Skip version bump commits (prevent infinite loop)
+          if echo "$MSG" | grep -qiE '^\[skip ci\]|^chore: bump version'; then
+            echo "type=skip" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Skip doc-only commits
+          if echo "$MSG" | grep -qiE '^docs(\(.*\))?:'; then
+            echo "type=skip" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if echo "$MSG" | grep -qiE '^feat(\(.*\))?:'; then
+            echo "type=minor" >> "$GITHUB_OUTPUT"
+          else
+            echo "type=patch" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Compute new version
+        if: steps.bump.outputs.type != 'skip'
+        id: version
+        run: |
+          BUMP="${{ steps.bump.outputs.type }}"
+
+          LATEST=$(git tag --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
+          if [ -z "$LATEST" ]; then
+            LATEST="v0.0.0"
+          fi
+          echo "Latest tag: $LATEST"
+
+          MAJOR=$(echo "$LATEST" | sed 's/v//' | cut -d. -f1)
+          MINOR=$(echo "$LATEST" | sed 's/v//' | cut -d. -f2)
+          PATCH=$(echo "$LATEST" | sed 's/v//' | cut -d. -f3)
+
+          if [ "$BUMP" = "minor" ]; then
+            MINOR=$((MINOR + 1))
+            PATCH=0
+          else
+            PATCH=$((PATCH + 1))
+          fi
+
+          NEW_TAG="v${MAJOR}.${MINOR}.${PATCH}"
+          echo "New tag: $NEW_TAG"
+          echo "tag=$NEW_TAG" >> "$GITHUB_OUTPUT"
+          echo "semver=${MAJOR}.${MINOR}.${PATCH}" >> "$GITHUB_OUTPUT"
+
+      - name: Update pubspec.yaml
+        if: steps.bump.outputs.type != 'skip'
+        run: |
+          SEMVER="${{ steps.version.outputs.semver }}"
+
+          # Extract current build number and increment it
+          CURRENT=$(grep '^version:' pubspec.yaml | sed 's/version: //')
+          BUILD=$(echo "$CURRENT" | cut -d+ -f2)
+          NEW_BUILD=$((BUILD + 1))
+
+          NEW_VERSION="${SEMVER}+${NEW_BUILD}"
+          echo "Updating pubspec.yaml version to $NEW_VERSION"
+
+          sed -i "s/^version: .*/version: ${NEW_VERSION}/" pubspec.yaml
+
+      - name: Commit and tag
+        if: steps.bump.outputs.type != 'skip'
+        run: |
+          TAG="${{ steps.version.outputs.tag }}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git add pubspec.yaml
+          git commit -m "chore: bump version to ${TAG} [skip ci]"
+          git tag "$TAG"
+          git push origin main "$TAG"

--- a/lib/components/pwa_update_banner.dart
+++ b/lib/components/pwa_update_banner.dart
@@ -1,0 +1,80 @@
+import 'dart:async';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:how_many_mobile_meeple/pwa/pwa_update_service.dart';
+import 'package:universal_html/js.dart' as js;
+
+class PwaUpdateBanner extends StatefulWidget {
+  const PwaUpdateBanner({super.key});
+
+  @override
+  State<PwaUpdateBanner> createState() => _PwaUpdateBannerState();
+}
+
+class _PwaUpdateBannerState extends State<PwaUpdateBanner> {
+  bool _visible = false;
+  StreamSubscription<bool>? _subscription;
+
+  @override
+  void initState() {
+    super.initState();
+    _subscription = PwaUpdateService.updateAvailable.listen((_) {
+      if (mounted) setState(() => _visible = true);
+    });
+  }
+
+  @override
+  void dispose() {
+    _subscription?.cancel();
+    super.dispose();
+  }
+
+  void _reload() {
+    if (kIsWeb) {
+      try {
+        js.context.callMethod('eval', ['window.location.reload()']);
+      } catch (_) {}
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!_visible) return const SizedBox.shrink();
+
+    const bannerColor = Color(0xFF1565C0); // blue 800 — matches theme_color
+    const textColor = Colors.white;
+
+    return Material(
+      color: bannerColor,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        child: Row(
+          children: [
+            const Icon(Icons.system_update_alt, size: 20, color: textColor),
+            const SizedBox(width: 10),
+            Expanded(
+              child: Text(
+                'A new version is available',
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: textColor,
+                    ),
+              ),
+            ),
+            TextButton(
+              onPressed: _reload,
+              style: TextButton.styleFrom(
+                foregroundColor: textColor,
+                visualDensity: VisualDensity.compact,
+                padding: const EdgeInsets.symmetric(horizontal: 8),
+              ),
+              child: const Text(
+                'Refresh',
+                style: TextStyle(fontWeight: FontWeight.bold, fontSize: 13),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/guided_flow_homepage.dart
+++ b/lib/guided_flow_homepage.dart
@@ -11,6 +11,7 @@ import 'package:how_many_mobile_meeple/guided_flow/step4_game_style.dart';
 import 'package:how_many_mobile_meeple/guided_flow/step5_final_actions.dart';
 import 'package:how_many_mobile_meeple/guided_flow/advanced_mode_widget.dart';
 import 'package:how_many_mobile_meeple/components/pwa_install_banner.dart';
+import 'package:how_many_mobile_meeple/components/pwa_update_banner.dart';
 import 'package:how_many_mobile_meeple/components/disclaimer_text.dart';
 import 'package:how_many_mobile_meeple/components/empty_widget.dart';
 import 'package:package_info_plus/package_info_plus.dart';
@@ -61,6 +62,7 @@ class _GuidedFlowHomePageState extends State<GuidedFlowHomePage> {
           drawer: widget.pageDrawer(context),
           body: Column(
             children: [
+              const PwaUpdateBanner(),
               const PwaInstallBanner(),
               Expanded(
                 child: _showAdvancedMode

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,15 +8,16 @@ import 'package:provider/provider.dart';
 
 import 'package:how_many_mobile_meeple/model/model.dart';
 import 'package:how_many_mobile_meeple/app_config.dart';
+import 'package:how_many_mobile_meeple/pwa/pwa_update_service.dart';
 
 import 'meeple_theme.dart';
 
 void main() async {
-  // Ensure Flutter bindings are initialized
   WidgetsFlutterBinding.ensureInitialized();
 
-  // Load configuration (API URL from config file for web)
   await AppConfig.initialize();
+
+  PwaUpdateService.start();
 
   runApp(const MyApp());
 }

--- a/lib/pwa/pwa_update_service.dart
+++ b/lib/pwa/pwa_update_service.dart
@@ -1,0 +1,42 @@
+import 'dart:async';
+import 'dart:convert';
+import 'package:flutter/foundation.dart';
+import 'package:http/http.dart' as http;
+import 'package:package_info_plus/package_info_plus.dart';
+
+class PwaUpdateService {
+  static final StreamController<bool> _updateController =
+      StreamController<bool>.broadcast();
+
+  static Stream<bool> get updateAvailable => _updateController.stream;
+
+  static bool get isWeb => kIsWeb;
+
+  static void start() {
+    if (!isWeb) return;
+    _check();
+  }
+
+  static Future<void> _check() async {
+    try {
+      final packageInfo = await PackageInfo.fromPlatform();
+      final running = packageInfo.version;
+
+      final response = await http
+          .get(Uri.parse(
+              '/version.json?_=${DateTime.now().millisecondsSinceEpoch}'))
+          .timeout(const Duration(seconds: 10));
+
+      if (response.statusCode != 200) return;
+
+      final data = json.decode(response.body) as Map<String, dynamic>;
+      final deployed = data['version'] as String?;
+
+      if (deployed != null && deployed != running) {
+        _updateController.add(true);
+      }
+    } catch (_) {
+      // Network errors are expected — silently ignore
+    }
+  }
+}


### PR DESCRIPTION
- Add tag-release.yml workflow: bumps pubspec.yaml version and pushes a semver tag on every merge to main (minor for feat, patch for all others, skip for docs)
- Add PwaUpdateService: single check on startup that fetches /version.json and emits on a stream if the deployed version differs from the running build
- Add PwaUpdateBanner: blue banner with Refresh button that appears when an update is detected
- Wire both into GuidedFlowHomePage and start the service in main()