### PR TITLE
feat: replace max complexity filter with around-complexity filter

### DIFF
--- a/lib/components/complexity_filter_widget.dart
+++ b/lib/components/complexity_filter_widget.dart
@@ -27,9 +27,9 @@ class ComplexityFilterWidget extends StatelessWidget {
                   width: MediaQuery.of(context).size.width * 0.60,
                   child: Slider(
                       activeColor: Theme.of(context).colorScheme.secondary,
-                      min: 0.0,
+                      min: 0.5,
                       max: 5.0,
-                      divisions: 10,
+                      divisions: 9,
                       onChanged: !model.settings
                               .setting(Settings.filterComplexity.name)
                               .enabled
@@ -43,15 +43,14 @@ class ComplexityFilterWidget extends StatelessWidget {
                             },
                       value: model.settings
                           .setting(Settings.filterComplexity.name)
-                          .getDouble(),
+                          .getDouble()
+                          .clamp(0.5, 5.0),
                       label:
-                          "${model.settings.setting(Settings.filterComplexity.name).value.toString()} weighting"),
+                          "~${model.settings.setting(Settings.filterComplexity.name).value.toString()} weighting"),
                 ),
                 FilterValueBadge(
-                  value: model.settings
-                      .setting(Settings.filterComplexity.name)
-                      .value
-                      .toString(),
+                  value:
+                      "~${model.settings.setting(Settings.filterComplexity.name).value.toString()}",
                   isEnabled: model.settings
                       .setting(Settings.filterComplexity.name)
                       .enabled,

--- a/lib/guided_flow/step4_game_style.dart
+++ b/lib/guided_flow/step4_game_style.dart
@@ -35,6 +35,7 @@ class _Step4GameStyleState extends State<Step4GameStyle> {
   };
 
   String _getDifficultyLabel(double weight) {
+    if (weight == 0.0) return 'Any';
     if (weight <= 1.5) return 'Light';
     if (weight <= 2.5) return 'Gateway';
     if (weight <= 3.5) return 'Strategy';
@@ -43,11 +44,16 @@ class _Step4GameStyleState extends State<Step4GameStyle> {
   }
 
   String _getDifficultyDescription(double weight) {
-    if (weight <= 1.5) return 'Easy to learn, quick to play';
-    if (weight <= 2.5) return 'Simple rules, engaging gameplay';
-    if (weight <= 3.5) return 'Deeper strategy, more complexity';
-    if (weight <= 4.0) return 'Complex rules, strategic depth';
-    return 'Maximum complexity and depth';
+    if (weight == 0.0) return 'Show games of any complexity';
+    if (weight <= 1.5)
+      return 'Easy to learn, quick to play (~${weight.toStringAsFixed(1)} weight)';
+    if (weight <= 2.5)
+      return 'Simple rules, engaging gameplay (~${weight.toStringAsFixed(1)} weight)';
+    if (weight <= 3.5)
+      return 'Deeper strategy, more complexity (~${weight.toStringAsFixed(1)} weight)';
+    if (weight <= 4.0)
+      return 'Complex rules, strategic depth (~${weight.toStringAsFixed(1)} weight)';
+    return 'Maximum complexity and depth (~${weight.toStringAsFixed(1)} weight)';
   }
 
   @override
@@ -304,7 +310,7 @@ class _Step4GameStyleState extends State<Step4GameStyle> {
           borderRadius: BorderRadius.circular(8),
           child: AnimatedContainer(
             duration: const Duration(milliseconds: 200),
-            padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 4),
+            padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 2),
             decoration: BoxDecoration(
               color: isSelected
                   ? Theme.of(context).colorScheme.primaryContainer
@@ -340,8 +346,8 @@ class _Step4GameStyleState extends State<Step4GameStyle> {
                             : Theme.of(context).colorScheme.onSurfaceVariant,
                       ),
                   textAlign: TextAlign.center,
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
+                  maxLines: 2,
+                  softWrap: true,
                 ),
               ],
             ),

--- a/lib/model/settings.dart
+++ b/lib/model/settings.dart
@@ -15,8 +15,8 @@ class Settings {
   static Setting filterMaximumTimeToPlay = Setting("maximumTimeToPlay",
       header: "Bgg-Filter-Max-Duration", value: 90);
 
-  static Setting filterComplexity = Setting("maximumComplexity",
-      header: "Bgg-Filter-Max-Complexity", value: 2.5);
+  static Setting filterComplexity =
+      Setting("complexity", header: "Bgg-Filter-Complexity", value: 0.0);
 
   static Setting filterUsingUserRecommendations = Setting(
       "useUserRecommendedFilters",


### PR DESCRIPTION
Backend breaking change: Bgg-Filter-Max-Complexity replaced by Bgg-Filter-Complexity, which returns games within +/-1.0 of the target.

- Update header and setting key to match new API
- Default value 0.0 (no filter / don't care)
- Add 'Don't care' option to guided flow difficulty panels
- Update descriptions to reflect target-based rather than ceiling logic
- Allow difficulty labels to wrap to two lines on narrow screens