### PR TITLE
feat: prefetch cache warming for collections and geeklists

### DIFF
--- a/lib/api/prefetch_service.dart
+++ b/lib/api/prefetch_service.dart
@@ -1,0 +1,26 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+import 'package:how_many_mobile_meeple/app_common.dart';
+import 'package:how_many_mobile_meeple/model/item.dart';
+
+class PrefetchService {
+  static final Set<String> _warmed = {};
+
+  static Future<void> warmCache(Item item) async {
+    final key = '${item.itemType.name}:${item.name}';
+    if (!_warmed.add(key)) return;
+    try {
+      await http.post(
+        Uri.parse('${AppCommon.boardGameGeekProxyUrl}/prefetch'),
+        headers: {'Content-Type': 'application/json'},
+        body: json.encode({
+          'source_type': item.itemType.name,
+          'source_id': item.name,
+        }),
+      );
+    } catch (_) {
+      // Fire-and-forget — failures are non-fatal
+      _warmed.remove(key);
+    }
+  }
+}

--- a/lib/components/board_game_item_input_widget.dart
+++ b/lib/components/board_game_item_input_widget.dart
@@ -3,6 +3,7 @@ import 'package:how_many_mobile_meeple/app_common.dart';
 import 'package:how_many_mobile_meeple/components/app_default_padding.dart';
 import 'package:how_many_mobile_meeple/model/item.dart';
 import 'package:how_many_mobile_meeple/model/model.dart';
+import 'package:how_many_mobile_meeple/api/prefetch_service.dart';
 import 'package:provider/provider.dart';
 
 /// Reusable board game item input widget (username/geeklist entry)
@@ -60,6 +61,7 @@ class _BoardGameItemInputWidgetState extends State<BoardGameItemInputWidget> {
                       model.addItem(item);
                       controller.text = '';
                       model.updateStore();
+                      PrefetchService.warmCache(item);
                     },
                   ),
                 ),

--- a/lib/guided_flow/step1_select_source.dart
+++ b/lib/guided_flow/step1_select_source.dart
@@ -5,6 +5,7 @@ import 'package:how_many_mobile_meeple/model/item.dart';
 import 'package:how_many_mobile_meeple/app_common.dart';
 import 'package:how_many_mobile_meeple/components/step_header_card.dart';
 import 'package:how_many_mobile_meeple/components/info_message_box.dart';
+import 'package:how_many_mobile_meeple/api/prefetch_service.dart';
 
 /// Step 1: Select Source of Games
 /// Allows users to add BGG usernames or geeklist IDs
@@ -157,6 +158,7 @@ class _Step1SelectSourceState extends State<Step1SelectSource> {
     item.itemType = _selectedType;
     model.addItem(item);
     model.updateStore();
+    PrefetchService.warmCache(item);
 
     _controller.clear();
 

--- a/lib/load_games.dart
+++ b/lib/load_games.dart
@@ -9,6 +9,9 @@ import 'model/game.dart';
 import 'model/games.dart';
 
 class LoadGames {
+  static const Duration _retryInterval = Duration(seconds: 10);
+  static const Duration _retryTimeout = Duration(seconds: 60);
+
   static Future<Games> fetchGames(Settings settings, List<Item> items) async {
     Games games = Games(gamesByName: Map<String, Game>());
     Map<String, String> requestHeaders = Map.fromEntries(settings
@@ -17,30 +20,35 @@ class LoadGames {
         .map((entry) =>
             MapEntry(entry.value.header!, entry.value.value.toString())));
 
-    // Create parallel HTTP requests for all items
-    final futures = items.map((item) async {
-      final itemName = Uri.encodeComponent(item.name);
-      var response = await http.get(
-          Uri.parse(
-              "${AppCommon.boardGameGeekProxyUrl}/${item.itemType.name}/$itemName"),
-          headers: requestHeaders.map((k, v) => MapEntry(k, v.toString())));
-
-      if (response.statusCode != 200) {
-        throw Exception('Failed to load games for ${item.name}');
-      }
-
-      return response;
-    });
-
-    // Wait for all requests to complete in parallel
+    final futures = items.map((item) => _fetchWithRetry(item, requestHeaders));
     final responses = await Future.wait(futures);
 
-    // Process all responses
     for (var response in responses) {
       Games loadedGames = Games.fromJson(jsonDecode(response.body));
       games.addGames(loadedGames);
     }
 
     return games;
+  }
+
+  static Future<http.Response> _fetchWithRetry(
+      Item item, Map<String, String> headers) async {
+    final url = Uri.parse(
+        "${AppCommon.boardGameGeekProxyUrl}/${item.itemType.name}/${Uri.encodeComponent(item.name)}");
+    final deadline = DateTime.now().add(_retryTimeout);
+
+    while (true) {
+      final response = await http.get(url,
+          headers: headers.map((k, v) => MapEntry(k, v.toString())));
+
+      if (response.statusCode == 200) return response;
+
+      if (response.statusCode == 202 && DateTime.now().isBefore(deadline)) {
+        await Future.delayed(_retryInterval);
+        continue;
+      }
+
+      throw Exception('Failed to load games for ${item.name}');
+    }
   }
 }

--- a/lib/model/model.dart
+++ b/lib/model/model.dart
@@ -8,6 +8,7 @@ import 'package:how_many_mobile_meeple/model/settings.dart';
 import 'package:how_many_mobile_meeple/model/bgg_cache.dart';
 import 'package:how_many_mobile_meeple/model/item.dart';
 
+import '../api/prefetch_service.dart';
 import '../app_common.dart';
 import 'game.dart';
 import 'games.dart';
@@ -135,6 +136,9 @@ class AppModel extends ChangeNotifier {
     replaceSettings(await store.loadSettings(settings));
     hasLoadedPersistedData = true;
     notifyListeners();
+    for (final item in _items.itemList) {
+      PrefetchService.warmCache(item);
+    }
   }
 
   Future<void> _storeSettings(Settings settings) async {


### PR DESCRIPTION
- Add PrefetchService that POSTs to /prefetch when a source is added, deduplicating requests within a session via an in-memory set
- Warm cache for all persisted sources on app startup via loadStoredData
- Handle 202 responses in LoadGames with a 10s retry interval up to 60s, preventing failures when the backend cache is still being populated