### PR TITLE
fix: stale cache served after removing a collection/geeklist

### DIFF
--- a/lib/components/board_game_item_input_widget.dart
+++ b/lib/components/board_game_item_input_widget.dart
@@ -60,7 +60,6 @@ class _BoardGameItemInputWidgetState extends State<BoardGameItemInputWidget> {
                       Item item = Item(controller.text.trim());
                       model.addItem(item);
                       controller.text = '';
-                      model.updateStore();
                       PrefetchService.warmCache(item);
                     },
                   ),

--- a/lib/guided_flow/step1_select_source.dart
+++ b/lib/guided_flow/step1_select_source.dart
@@ -157,7 +157,6 @@ class _Step1SelectSourceState extends State<Step1SelectSource> {
     final item = Item(_controller.text.trim());
     item.itemType = _selectedType;
     model.addItem(item);
-    model.updateStore();
     PrefetchService.warmCache(item);
 
     _controller.clear();
@@ -211,7 +210,6 @@ class _Step1SelectSourceState extends State<Step1SelectSource> {
               icon: const Icon(Icons.close, size: 20),
               onPressed: () {
                 model.deleteItem(item);
-                model.updateStore();
               },
               tooltip: 'Remove',
             ),

--- a/lib/how_many_meeple_app_bar.dart
+++ b/lib/how_many_meeple_app_bar.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:how_many_mobile_meeple/platform/pages.dart';
+import 'package:how_many_mobile_meeple/platform/router.dart' as r;
 import 'package:how_many_mobile_meeple/save_dialog.dart';
 import 'package:url_launcher/url_launcher.dart';
 
@@ -21,9 +21,8 @@ class HowManyMeepleAppBar extends AppBar {
               : IconButton(
                   icon: Icon(Icons.home),
                   onPressed: () {
-                    Navigator.of(context).push(MaterialPageRoute(
-                        builder: (BuildContext context) =>
-                            Pages.platformPages().homePage()));
+                    Navigator.of(context).pushNamedAndRemoveUntil(
+                        r.Router.homeRoute, (route) => false);
                   }),
           title: Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,

--- a/lib/model/game_request.dart
+++ b/lib/model/game_request.dart
@@ -13,7 +13,10 @@ class GameRequest {
           .where((e) => e.value.header != null)
           .map((e) => MapEntry(e.value.header!, e.value.value.toString())),
     );
-    return GameRequest(items: items, headers: headers);
+    // Snapshot the items list so mutations after this point don't affect the
+    // request's identity (e.g. deleteItem removing from the live list).
+    final snapshot = Items(List.unmodifiable(items.itemList));
+    return GameRequest(items: snapshot, headers: headers);
   }
 
   String get _headersKey {

--- a/lib/model/model.dart
+++ b/lib/model/model.dart
@@ -24,6 +24,7 @@ class AppModel extends ChangeNotifier {
 
   bool hasLoadedPersistedData = false;
   bool pageRefreshed = false;
+  bool _urlConsumed = false;
 
   String? title;
 
@@ -50,7 +51,9 @@ class AppModel extends ChangeNotifier {
   }
 
   Future<void> refreshFromUrl() async {
+    if (_urlConsumed) return;
     if (_extractor.containsModel()) {
+      _urlConsumed = true;
       await replaceItems(_extractor.extractItems());
       var extractedSettings = _extractor.extractSettings();
       extractedSettings = _rebuildUrlMechanics(extractedSettings);
@@ -118,9 +121,8 @@ class AppModel extends ChangeNotifier {
 
   Future<void> deleteItem(Item item) async {
     _items.itemList.remove(item);
-    await _storeItems(_items);
     invalidateCache();
-    notifyListeners();
+    await _storeItems(_items);
   }
 
   Future<void> updateStore() async {
@@ -136,6 +138,7 @@ class AppModel extends ChangeNotifier {
   Future<void> loadStoredData() async {
     if (_extractor.containsModel()) {
       hasLoadedPersistedData = true;
+      _urlConsumed = true;
       return;
     }
     StoredPreferences store = await StorageFactory.getStoredPreferences();

--- a/test/model/app_model_cache_test.dart
+++ b/test/model/app_model_cache_test.dart
@@ -1,0 +1,107 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:how_many_mobile_meeple/model/game_request.dart';
+import 'package:how_many_mobile_meeple/model/item.dart';
+import 'package:how_many_mobile_meeple/model/model.dart';
+import 'package:how_many_mobile_meeple/model/settings.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../test_helpers.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  group('AppModel.replaceCache stale-response guard', () {
+    test('accepts response when request matches current model state', () {
+      final model = AppModel()..hasLoadedPersistedData = true;
+      model.items.itemList.add(Item('teqqles'));
+
+      final request = model.buildRequest();
+      final games = TestHelpers.twoGames();
+
+      model.invalidateCache();
+      model.replaceCache(games, request);
+
+      expect(model.bggCache.isStale(), false);
+      expect(model.bggCache.games, games);
+    });
+
+    test(
+        'rejects response when items have changed since fetch started — '
+        'simulates background fetcher refilling cache after deleteItem', () {
+      final model = AppModel()..hasLoadedPersistedData = true;
+      // Setup: two items
+      model.items.itemList.add(Item('teqqles'));
+      model.items.itemList.add(Item('dragonc'));
+
+      // Fetch was kicked off with teqqles+dragonc
+      final staleRequest = model.buildRequest();
+      final staleGames = TestHelpers.twoGames();
+
+      // User removes dragonc — cache becomes stale, items shrink to [teqqles]
+      model.items.itemList.remove(Item('dragonc'));
+      model.invalidateCache();
+
+      // Stale fetch completes and tries to fill the cache
+      model.replaceCache(staleGames, staleRequest);
+
+      // Cache must remain stale — stale response was rejected
+      expect(model.bggCache.isStale(), true,
+          reason: 'stale response from old items set must be rejected');
+    });
+
+    test(
+        'rejects response when headers have changed since fetch started — '
+        'simulates in-flight fetch completing after a filter change', () {
+      final model = AppModel()..hasLoadedPersistedData = true;
+      model.items.itemList.add(Item('teqqles'));
+
+      // Fetch was kicked off with player count = 8
+      final settingsAt8Players = Settings.defaultSettings();
+      settingsAt8Players.setting(Settings.filterNumberOfPlayers.name).value =
+          '8';
+      settingsAt8Players.setting(Settings.filterNumberOfPlayers.name).enabled =
+          true;
+      final staleRequest = GameRequest.from(
+        settingsAt8Players,
+        model.items,
+      );
+      final staleGames = TestHelpers.twoGames();
+
+      // User changes player count to 6
+      model.settings.setting(Settings.filterNumberOfPlayers.name).value = '6';
+      model.settings.setting(Settings.filterNumberOfPlayers.name).enabled =
+          true;
+      model.invalidateCache();
+
+      // In-flight fetch for player=8 completes
+      model.replaceCache(staleGames, staleRequest);
+
+      expect(model.bggCache.isStale(), true,
+          reason: 'stale response with old headers must be rejected');
+    });
+
+    test(
+        'accepts fresh response after deleteItem invalidates and new fetch '
+        'completes with updated items', () {
+      final model = AppModel()..hasLoadedPersistedData = true;
+      model.items.itemList.add(Item('teqqles'));
+      model.items.itemList.add(Item('dragonc'));
+
+      model.items.itemList.remove(Item('dragonc'));
+      model.invalidateCache();
+
+      // New fetch completes with only teqqles
+      final freshRequest = model.buildRequest();
+      final freshGames = TestHelpers.oneGame();
+
+      model.replaceCache(freshGames, freshRequest);
+
+      expect(model.bggCache.isStale(), false);
+      expect(model.bggCache.games, freshGames);
+    });
+  });
+}

--- a/test/test_helpers.dart
+++ b/test/test_helpers.dart
@@ -1,0 +1,31 @@
+import 'package:how_many_mobile_meeple/model/game.dart';
+import 'package:how_many_mobile_meeple/model/games.dart';
+
+class TestHelpers {
+  static Game game1() => Game(
+        id: 1,
+        name: 'Wingspan',
+        maxPlayers: 5,
+        minPlayers: 1,
+        maxPlaytime: 70,
+        imageUrl: 'http://example.com/wingspan.jpg',
+        averageRating: 8.1,
+        averageWeight: 2.4,
+      );
+
+  static Game game2() => Game(
+        id: 2,
+        name: 'Catan',
+        maxPlayers: 4,
+        minPlayers: 3,
+        maxPlaytime: 120,
+        imageUrl: 'http://example.com/catan.jpg',
+        averageRating: 7.2,
+        averageWeight: 2.3,
+      );
+
+  static Games twoGames() =>
+      Games(gamesByName: {game1().name: game1(), game2().name: game2()});
+
+  static Games oneGame() => Games(gamesByName: {game1().name: game1()});
+}


### PR DESCRIPTION
GameRequest.from() was storing a reference to the live Items list rather than a snapshot. When deleteItem() mutated that list, it retroactively changed the identity of every in-flight GameRequest, causing replaceCache() to accept results fetched for the old item set.

Also fixed: the home button used Navigator.push, leaving list/random pages alive in the stack. Those buried _GameFetcher widgets remained subscribed to notifyListeners and would re-fetch in the background on any model change, repopulating the cache with stale data before the user navigated.

Fixes:
- GameRequest.from() now snapshots items with List.unmodifiable
- Home button uses pushNamedAndRemoveUntil to clear the navigation stack
- Added regression tests covering the stale-response guard in replaceCache