### PR TITLE
feat: add game detail page with cached API, share permalink, and imag…

### DIFF
--- a/lib/api/game_detail_service.dart
+++ b/lib/api/game_detail_service.dart
@@ -1,0 +1,43 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+import 'package:how_many_mobile_meeple/app_common.dart';
+import 'package:how_many_mobile_meeple/model/game.dart';
+import 'package:how_many_mobile_meeple/model/settings.dart';
+
+class _CachedGame {
+  final Game game;
+  final int timestamp;
+
+  _CachedGame(this.game, this.timestamp);
+
+  bool get isStale =>
+      DateTime.now().millisecondsSinceEpoch - timestamp > _cacheDurationMs;
+
+  static const int _cacheDurationMs = 30 * 60 * 1000;
+}
+
+class GameDetailService {
+  static final Map<int, _CachedGame> _cache = {};
+
+  static Future<Game> fetchGame(int gameId) async {
+    final cached = _cache[gameId];
+    if (cached != null && !cached.isStale) {
+      return cached.game;
+    }
+
+    final url = Uri.parse('${AppCommon.boardGameGeekProxyUrl}/game/$gameId');
+
+    final response = await http.get(url, headers: {
+      Settings.fieldsToReturnFromApi.header!:
+          Settings.fieldsToReturnFromApi.value.toString(),
+    });
+
+    if (response.statusCode == 200) {
+      final game = Game.fromJson(jsonDecode(response.body));
+      _cache[gameId] = _CachedGame(game, DateTime.now().millisecondsSinceEpoch);
+      return game;
+    }
+
+    throw Exception('Failed to load game $gameId');
+  }
+}

--- a/lib/api/recommendations_service.dart
+++ b/lib/api/recommendations_service.dart
@@ -1,0 +1,37 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+import 'package:how_many_mobile_meeple/app_common.dart';
+import 'package:how_many_mobile_meeple/model/recommendation.dart';
+
+class RecommendationsService {
+  static Future<List<Recommendation>> fetchRecommendations({
+    required List<int> gameIds,
+    required Map<String, String> headers,
+    int limit = 10,
+    List<int> excludeIds = const [],
+  }) async {
+    final url = Uri.parse(
+        '${AppCommon.boardGameGeekProxyUrl}/recommendations/from-games');
+
+    final response = await http.post(
+      url,
+      headers: {
+        ...headers,
+        'Content-Type': 'application/json',
+      },
+      body: json.encode({
+        'game_ids': gameIds,
+        'limit': limit,
+        'exclude_ids': excludeIds,
+      }),
+    );
+
+    if (response.statusCode == 200) {
+      final body = jsonDecode(response.body);
+      final list = body['recommendations'] as List<dynamic>;
+      return list.map((r) => Recommendation.fromJson(r)).toList();
+    }
+
+    throw Exception('Failed to load recommendations');
+  }
+}

--- a/lib/app_page.dart
+++ b/lib/app_page.dart
@@ -1,10 +1,7 @@
-import 'dart:typed_data';
-
-import 'package:share_plus/share_plus.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:share_plus/share_plus.dart';
 import 'package:how_many_mobile_meeple/platform/router.dart' as r;
-import 'package:mime/mime.dart';
-import 'package:http/http.dart' as http;
 import 'package:provider/provider.dart';
 import 'package:how_many_mobile_meeple/components/drawer_bgg_filter.dart';
 import 'package:how_many_mobile_meeple/components/drawer_switch.dart';
@@ -14,7 +11,6 @@ import 'components/component_factory.dart';
 import 'model/game.dart';
 import 'model/model.dart';
 import 'model/settings.dart';
-import 'package:path/path.dart';
 import 'pwa/pwa_install_service.dart';
 import 'theme_extensions.dart';
 
@@ -245,26 +241,57 @@ mixin AppPage {
         color: Theme.of(context).selectedRowColor,
       ),
       onPressed: () async {
-        var response = await http.get(Uri.parse(game.imageUrl));
-        var mimeType = lookupMimeType(basename(game.imageUrl));
-        Uint8List bytes = response.bodyBytes;
-        final xFile = XFile.fromData(
-          bytes,
-          name: basename(game.imageUrl),
-          mimeType: mimeType,
-        );
-        await SharePlus.instance.share(
-          ShareParams(
-            files: [xFile],
-            text: AppCommon.randomGameMessage(game.name),
-          ),
-        );
+        final baseUri = Uri.base.removeFragment();
+        final uri = baseUri.replace(
+            fragment: '/game/${game.name.replaceAll(' ', '+')}/${game.id}');
+        final url = uri.toString();
+        try {
+          final result = await SharePlus.instance.share(
+            ShareParams(
+              title: game.name,
+              text: AppCommon.randomGameMessage(game.name),
+              uri: uri,
+            ),
+          );
+          if (result.status == ShareResultStatus.unavailable) {
+            _showCopyLinkDialog(context, url);
+          }
+        } catch (_) {
+          _showCopyLinkDialog(context, url);
+        }
       },
       style: ButtonStyle(
           backgroundColor: WidgetStateProperty.all<Color>(
               Theme.of(context).colorScheme.secondary),
           shape: WidgetStateProperty.all<OutlinedBorder>(RoundedRectangleBorder(
               borderRadius: BorderRadius.circular(30.0)))),
+    );
+  }
+
+  void _showCopyLinkDialog(BuildContext context, String url) {
+    showDialog(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: const Text('Share Link'),
+        content: SelectableText(url),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(),
+            child: const Text('Close'),
+          ),
+          FilledButton.icon(
+            onPressed: () {
+              Clipboard.setData(ClipboardData(text: url));
+              Navigator.of(dialogContext).pop();
+              ScaffoldMessenger.of(context).showSnackBar(
+                const SnackBar(content: Text('Link copied to clipboard')),
+              );
+            },
+            icon: const Icon(Icons.copy),
+            label: const Text('Copy Link'),
+          ),
+        ],
+      ),
     );
   }
 

--- a/lib/components/game_image_with_stats.dart
+++ b/lib/components/game_image_with_stats.dart
@@ -1,0 +1,116 @@
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+import 'package:how_many_mobile_meeple/components/platform_independent_image.dart';
+import 'package:how_many_mobile_meeple/model/game.dart';
+import 'package:how_many_mobile_meeple/screen_tools.dart';
+
+class GameImageWithStats extends StatelessWidget with ScreenTools {
+  final Game game;
+
+  GameImageWithStats({super.key, required this.game});
+
+  @override
+  Widget build(BuildContext context) {
+    final maxHeight = getScreenHeightPercentageInPixels(
+        context, ScreenTools.fiftyPercentScreen);
+    return ClipRect(
+      child: ConstrainedBox(
+        constraints: BoxConstraints(maxHeight: maxHeight),
+        child: Stack(
+          clipBehavior: Clip.hardEdge,
+          children: [
+            SizedBox(
+              width: double.infinity,
+              child: PlatformIndependentImage(
+                imageUrl: game.imageUrl,
+                fit: BoxFit.fitWidth,
+              ),
+            ),
+            Positioned(
+              right: 0,
+              bottom: 0,
+              child: Container(
+                decoration: BoxDecoration(
+                  color: Theme.of(context).colorScheme.primary.withAlpha(192),
+                  borderRadius: const BorderRadius.only(
+                    topLeft: Radius.circular(12),
+                  ),
+                  border: Border.all(color: Colors.white, width: 1.5),
+                  boxShadow: [
+                    BoxShadow(
+                      color: Colors.black.withAlpha(64),
+                      blurRadius: 8,
+                      offset: const Offset(0, 2),
+                    ),
+                  ],
+                ),
+                padding:
+                    const EdgeInsets.symmetric(vertical: 16, horizontal: 20),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    _StatChip(
+                      icon: Icons.people,
+                      label: game.minPlayers == game.maxPlayers
+                          ? '${game.minPlayers} players'
+                          : '${game.minPlayers}-${game.maxPlayers} players',
+                    ),
+                    const SizedBox(height: 14),
+                    _StatChip(
+                      icon: Icons.timer,
+                      label: '${game.maxPlaytime} min',
+                    ),
+                    const SizedBox(height: 14),
+                    _StatChip(
+                      icon: Icons.fitness_center,
+                      label: '${game.averageWeight.toStringAsFixed(1)} / 5',
+                    ),
+                    const SizedBox(height: 14),
+                    MouseRegion(
+                      cursor: SystemMouseCursors.click,
+                      child: GestureDetector(
+                        onTap: () => launchUrl(Uri.parse(
+                            'https://www.boardgamegeek.com/boardgame/${game.id}')),
+                        child: const _StatChip(
+                          icon: Icons.open_in_new,
+                          label: 'BoardGameGeek',
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _StatChip extends StatelessWidget {
+  final IconData icon;
+  final String label;
+
+  const _StatChip({required this.icon, required this.label});
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(icon, color: Colors.white, size: 18),
+        const SizedBox(width: 4),
+        Text(
+          label,
+          style: const TextStyle(
+            color: Colors.white,
+            fontSize: 13,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/components/platform_independent_image.dart
+++ b/lib/components/platform_independent_image.dart
@@ -10,28 +10,37 @@ import '../screen_tools.dart';
 
 class PlatformIndependentImage extends StatelessWidget with ScreenTools {
   final String imageUrl;
+  final BoxFit? fit;
   final Codec<String, String> stringToBase64 = utf8.fuse(base64Url);
 
-  PlatformIndependentImage({super.key, required this.imageUrl});
+  PlatformIndependentImage({super.key, required this.imageUrl, this.fit});
 
   Widget buildWebImage(context) {
     return Image.network(
         AppCommon.boardGameGeekProxyUrl +
             "/cors-proxy/_" +
             stringToBase64.encode(this.imageUrl),
-        height: getScreenHeightPercentageInPixels(
-            context, ScreenTools.fiftyPercentScreen),
-        fit: BoxFit.fitHeight);
+        height: fit == null
+            ? getScreenHeightPercentageInPixels(
+                context, ScreenTools.fiftyPercentScreen)
+            : null,
+        alignment: Alignment.topCenter,
+        fit: fit ?? BoxFit.fitHeight);
   }
 
   Widget buildMobileCachedImage(context) {
     return CachedNetworkImage(
       imageUrl: this.imageUrl,
       imageBuilder: (context, provider) => Container(
-        height: getScreenHeightPercentageInPixels(
-            context, ScreenTools.fiftyPercentScreen),
+        height: fit == null
+            ? getScreenHeightPercentageInPixels(
+                context, ScreenTools.fiftyPercentScreen)
+            : null,
         decoration: BoxDecoration(
-          image: DecorationImage(image: provider, fit: BoxFit.fitHeight),
+          image: DecorationImage(
+              image: provider,
+              fit: fit ?? BoxFit.fitHeight,
+              alignment: Alignment.topCenter),
         ),
       ),
       placeholder: (context, url) => SpinKitCubeGrid(

--- a/lib/components/recommendations_widget.dart
+++ b/lib/components/recommendations_widget.dart
@@ -1,0 +1,172 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:how_many_mobile_meeple/api/recommendations_service.dart';
+import 'package:how_many_mobile_meeple/app_common.dart';
+import 'package:how_many_mobile_meeple/model/game.dart';
+import 'package:how_many_mobile_meeple/model/model.dart';
+import 'package:how_many_mobile_meeple/model/recommendation.dart';
+import 'package:how_many_mobile_meeple/platform/router.dart' as r;
+
+class RecommendationsWidget extends StatefulWidget {
+  final Game sourceGame;
+  final AppModel model;
+
+  const RecommendationsWidget({
+    super.key,
+    required this.sourceGame,
+    required this.model,
+  });
+
+  @override
+  State<RecommendationsWidget> createState() => _RecommendationsWidgetState();
+}
+
+class _RecommendationsWidgetState extends State<RecommendationsWidget> {
+  late Future<List<Recommendation>> _future;
+
+  @override
+  void initState() {
+    super.initState();
+    _future = _fetchRecommendations();
+  }
+
+  Future<List<Recommendation>> _fetchRecommendations() {
+    final headers = Map.fromEntries(
+      widget.model.settings.enabledSettings.entries
+          .where((e) => e.value.header != null)
+          .map((e) => MapEntry(e.value.header!, e.value.value.toString())),
+    );
+
+    return RecommendationsService.fetchRecommendations(
+      gameIds: [widget.sourceGame.id],
+      headers: headers,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<List<Recommendation>>(
+      future: _future,
+      builder: (context, snapshot) {
+        if (snapshot.hasError || (snapshot.hasData && snapshot.data!.isEmpty)) {
+          return const SizedBox.shrink();
+        }
+        if (!snapshot.hasData) {
+          return const SizedBox.shrink();
+        }
+        final recommendations = snapshot.data!;
+        return Padding(
+          padding: const EdgeInsets.only(top: 16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              Padding(
+                padding: const EdgeInsets.only(bottom: 8),
+                child: Text(
+                  'These Games Are Similar',
+                  style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
+                ),
+              ),
+              SizedBox(
+                height: 140,
+                child: LayoutBuilder(
+                  builder: (context, constraints) {
+                    final contentWidth = recommendations.length * 100.0 +
+                        (recommendations.length - 1) * 12.0;
+                    final needsScroll = contentWidth > constraints.maxWidth;
+                    final row = Row(
+                      mainAxisSize: MainAxisSize.min,
+                      spacing: 12,
+                      children: recommendations
+                          .map((r) => _RecommendationTile(recommendation: r))
+                          .toList(),
+                    );
+                    if (needsScroll) {
+                      final controller = ScrollController();
+                      return ScrollConfiguration(
+                        behavior: ScrollConfiguration.of(context)
+                            .copyWith(dragDevices: {
+                          PointerDeviceKind.touch,
+                          PointerDeviceKind.mouse,
+                        }),
+                        child: Scrollbar(
+                          controller: controller,
+                          thumbVisibility: true,
+                          interactive: true,
+                          child: SingleChildScrollView(
+                            controller: controller,
+                            scrollDirection: Axis.horizontal,
+                            child: row,
+                          ),
+                        ),
+                      );
+                    }
+                    return Center(child: row);
+                  },
+                ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _RecommendationTile extends StatelessWidget {
+  static final Codec<String, String> _base64 = utf8.fuse(base64Url);
+
+  final Recommendation recommendation;
+
+  const _RecommendationTile({required this.recommendation});
+
+  String _proxyUrl(String url) {
+    if (!kIsWeb) return url;
+    return '${AppCommon.boardGameGeekProxyUrl}/cors-proxy/_${_base64.encode(url)}';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MouseRegion(
+      cursor: SystemMouseCursors.click,
+      child: GestureDetector(
+        onTap: () => Navigator.of(context).pushNamed(
+            '${r.Router.gameDetailRoute}/${recommendation.name.replaceAll(' ', '+')}/${recommendation.gameId}'),
+        child: SizedBox(
+          width: 100,
+          child: Column(
+            children: [
+              ClipRRect(
+                borderRadius: BorderRadius.circular(8),
+                child: SizedBox(
+                  height: 100,
+                  width: 100,
+                  child: recommendation.game?.imageUrl != null
+                      ? Image.network(
+                          _proxyUrl(recommendation.game!.thumbnail ??
+                              recommendation.game!.imageUrl),
+                          fit: BoxFit.cover,
+                          errorBuilder: (_, __, ___) =>
+                              const Icon(Icons.image_not_supported),
+                        )
+                      : const Icon(Icons.extension, size: 48),
+                ),
+              ),
+              const SizedBox(height: 4),
+              Text(
+                recommendation.name,
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+                textAlign: TextAlign.center,
+                style: const TextStyle(fontSize: 11),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/model/game.dart
+++ b/lib/model/game.dart
@@ -7,6 +7,7 @@ class Game {
   final int minPlayers;
   final int maxPlaytime;
   final String imageUrl;
+  final String? thumbnail;
   final double averageRating;
   final double averageWeight;
 
@@ -17,6 +18,7 @@ class Game {
     required this.minPlayers,
     required this.maxPlaytime,
     required this.imageUrl,
+    this.thumbnail,
     required this.averageRating,
     required this.averageWeight,
   });
@@ -29,6 +31,7 @@ class Game {
       minPlayers: json['minplayers'],
       maxPlaytime: json['maxplaytime'] ?? 0,
       imageUrl: json['image'],
+      thumbnail: json['thumbnail'],
       averageRating: json['stats']['average'] ?? 0,
       averageWeight: json['stats']['averageweight'] ?? 0,
     );

--- a/lib/model/recommendation.dart
+++ b/lib/model/recommendation.dart
@@ -1,0 +1,26 @@
+import 'package:how_many_mobile_meeple/model/game.dart';
+
+class Recommendation {
+  final int gameId;
+  final String name;
+  final double similarityScore;
+  final Game? game;
+
+  Recommendation({
+    required this.gameId,
+    required this.name,
+    required this.similarityScore,
+    this.game,
+  });
+
+  factory Recommendation.fromJson(Map<String, dynamic> json) {
+    return Recommendation(
+      gameId: json['game_id'],
+      name: json['name'],
+      similarityScore: (json['similarity_score'] as num).toDouble(),
+      game: json['game'] != null
+          ? Game.fromJson(json['game'] as Map<String, dynamic>)
+          : null,
+    );
+  }
+}

--- a/lib/platform/common/game_detail_page.dart
+++ b/lib/platform/common/game_detail_page.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:how_many_mobile_meeple/api/game_detail_service.dart';
+import 'package:how_many_mobile_meeple/components/app_default_padding.dart';
+import 'package:how_many_mobile_meeple/components/game_image_with_stats.dart';
+import 'package:how_many_mobile_meeple/components/recommendations_widget.dart';
+import 'package:how_many_mobile_meeple/how_many_meeple_app_bar.dart';
+import 'package:how_many_mobile_meeple/model/game.dart';
+import 'package:how_many_mobile_meeple/model/model.dart';
+import 'package:how_many_mobile_meeple/screen_tools.dart';
+import 'package:how_many_mobile_meeple/app_page.dart';
+
+class GameDetailPage extends StatefulWidget {
+  final int gameId;
+
+  const GameDetailPage({super.key, required this.gameId});
+
+  @override
+  State<GameDetailPage> createState() => _GameDetailPageState();
+}
+
+class _GameDetailPageState extends State<GameDetailPage>
+    with ScreenTools, AppPage {
+  late Future<Game> _future;
+
+  @override
+  void initState() {
+    super.initState();
+    _future = GameDetailService.fetchGame(widget.gameId);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: HowManyMeepleAppBar('Game Details', context: context),
+      persistentFooterButtons: [iconButtonGroup(context)],
+      body: FutureBuilder<Game>(
+        future: _future,
+        builder: (context, snapshot) {
+          if (snapshot.hasError) {
+            return Center(child: Text('Failed to load game'));
+          }
+          if (!snapshot.hasData) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          return _buildGameDisplay(context, snapshot.data!);
+        },
+      ),
+    );
+  }
+
+  Widget _buildGameDisplay(BuildContext context, Game game) {
+    final model = Provider.of<AppModel>(context, listen: false);
+    return SingleChildScrollView(
+      child: Center(
+        child: Container(
+          width: getScreenWidthPercentageInPixels(
+              context, ScreenTools.eightyPercentScreen),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              AppDefaultPadding(
+                child: Text(
+                  game.name,
+                  style: TextStyle(fontWeight: FontWeight.bold),
+                  textAlign: TextAlign.center,
+                ),
+              ),
+              AppDefaultPadding(child: GameImageWithStats(game: game)),
+              shareButton(context, game),
+              RecommendationsWidget(sourceGame: game, model: model),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/platform/mobile/basic_list_games_display.dart
+++ b/lib/platform/mobile/basic_list_games_display.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:sprintf/sprintf.dart';
 import 'package:how_many_mobile_meeple/components/app_default_padding.dart';
-import 'package:url_launcher/url_launcher.dart';
+import 'package:how_many_mobile_meeple/platform/router.dart' as r;
 import '../../app_page.dart';
 import '../../app_common.dart';
 import 'package:how_many_mobile_meeple/components/heading_text.dart';
@@ -101,8 +101,8 @@ class BasicListGamesDisplayPage extends NetworkWidget with AppPage {
                                       style: TextStyle(
                                         decoration: TextDecoration.underline,
                                       )),
-                                  onTap: () => launchUrl(Uri.parse(
-                                      "https://www.boardgamegeek.com/boardgame/${game.id}"))),
+                                  onTap: () => Navigator.of(context).pushNamed(
+                                      '${r.Router.gameDetailRoute}/${game.name.replaceAll(' ', '+')}/${game.id}')),
                             ),
                           ),
                         ),

--- a/lib/platform/mobile/mobile_random_game_display.dart
+++ b/lib/platform/mobile/mobile_random_game_display.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:how_many_mobile_meeple/components/platform_independent_image.dart';
+import 'package:how_many_mobile_meeple/components/game_image_with_stats.dart';
+import 'package:how_many_mobile_meeple/components/recommendations_widget.dart';
 import 'package:how_many_mobile_meeple/platform/common/game_display_page.dart';
 import 'package:how_many_mobile_meeple/screen_tools.dart';
 
@@ -27,25 +28,27 @@ class MobileRandomGameDisplayPage extends GameDisplayPage {
       return const Center(child: Text('No game available'));
     }
     updatePageRefreshedStatus(model);
-    return Center(
-      child: Container(
-        width: getScreenWidthPercentageInPixels(
-            context, ScreenTools.eightyPercentScreen),
-        child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              AppDefaultPadding(
-                child: Text(
-                  game.name,
-                  style: TextStyle(fontWeight: FontWeight.bold),
-                  textAlign: TextAlign.center,
+    return SingleChildScrollView(
+      child: Center(
+        child: Container(
+          width: getScreenWidthPercentageInPixels(
+              context, ScreenTools.eightyPercentScreen),
+          child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                AppDefaultPadding(
+                  child: Text(
+                    game.name,
+                    style: TextStyle(fontWeight: FontWeight.bold),
+                    textAlign: TextAlign.center,
+                  ),
                 ),
-              ),
-              AppDefaultPadding(
-                  child: PlatformIndependentImage(imageUrl: game.imageUrl)),
-              shareButton(context, game),
-            ]),
+                AppDefaultPadding(child: GameImageWithStats(game: game)),
+                shareButton(context, game),
+                RecommendationsWidget(sourceGame: game, model: model),
+              ]),
+        ),
       ),
     );
   }

--- a/lib/platform/router.dart
+++ b/lib/platform/router.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:how_many_mobile_meeple/model/model.dart';
+import 'package:how_many_mobile_meeple/platform/common/game_detail_page.dart';
 import 'package:how_many_mobile_meeple/platform/pages.dart';
 import 'package:how_many_mobile_meeple/platform/web/url_fragment_encoder.dart';
 import 'package:how_many_mobile_meeple/settings_summary_page.dart';
@@ -9,6 +10,7 @@ class Router {
   static const String listRoute = '/list';
   static const String randomRoute = '/random';
   static const String settingsRoute = '/settings';
+  static const String gameDetailRoute = '/game';
 
   static List<String> routeList = [
     randomRoute,
@@ -22,6 +24,17 @@ class Router {
     var path = secondSlash == -1
         ? settings.name!
         : settings.name!.substring(0, secondSlash + 1);
+
+    if (path == Router.gameDetailRoute) {
+      final segments =
+          settings.name!.split('/').where((s) => s.isNotEmpty).toList();
+      final idStr = segments.last;
+      final gameId = int.tryParse(idStr);
+      if (gameId != null) {
+        return MaterialPageRoute(
+            builder: (_) => GameDetailPage(gameId: gameId), settings: settings);
+      }
+    }
 
     switch (path) {
       case Router.homeRoute:

--- a/lib/platform/web_or_tablet/enhanced_list_games_display.dart
+++ b/lib/platform/web_or_tablet/enhanced_list_games_display.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:sprintf/sprintf.dart';
 import 'package:how_many_mobile_meeple/components/app_default_padding.dart';
-import 'package:url_launcher/url_launcher.dart';
+import 'package:how_many_mobile_meeple/platform/router.dart' as r;
 import '../../app_page.dart';
 import '../../app_common.dart';
 import 'package:how_many_mobile_meeple/components/heading_text.dart';
@@ -119,8 +119,8 @@ class EnhancedListGamesDisplayPage extends NetworkWidget with AppPage {
                                             decoration:
                                                 TextDecoration.underline,
                                           )),
-                                      onTap: () => launchUrl(Uri.parse(
-                                          "https://www.boardgamegeek.com/boardgame/${game.id}")))),
+                                      onTap: () => Navigator.of(context).pushNamed(
+                                          '${r.Router.gameDetailRoute}/${game.name.replaceAll(' ', '+')}/${game.id}'))),
                             )),
                         TableCell(
                           verticalAlignment: TableCellVerticalAlignment.middle,

--- a/lib/platform/web_or_tablet/web_random_game_display.dart
+++ b/lib/platform/web_or_tablet/web_random_game_display.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:how_many_mobile_meeple/components/platform_independent_image.dart';
+import 'package:how_many_mobile_meeple/components/game_image_with_stats.dart';
+import 'package:how_many_mobile_meeple/components/recommendations_widget.dart';
 import 'package:how_many_mobile_meeple/platform/common/game_display_page.dart';
 import 'package:how_many_mobile_meeple/screen_tools.dart';
 
@@ -27,24 +28,26 @@ class WebRandomGameDisplayPage extends GameDisplayPage {
       return const Center(child: Text('No game available'));
     }
     updatePageRefreshedStatus(model);
-    return Center(
-      child: Container(
-        width: getScreenWidthPercentageInPixels(
-            context, ScreenTools.eightyPercentScreen),
-        child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              AppDefaultPadding(
-                child: Text(
-                  game.name,
-                  style: TextStyle(fontWeight: FontWeight.bold),
-                  textAlign: TextAlign.center,
+    return SingleChildScrollView(
+      child: Center(
+        child: Container(
+          width: getScreenWidthPercentageInPixels(
+              context, ScreenTools.eightyPercentScreen),
+          child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                AppDefaultPadding(
+                  child: Text(
+                    game.name,
+                    style: TextStyle(fontWeight: FontWeight.bold),
+                    textAlign: TextAlign.center,
+                  ),
                 ),
-              ),
-              AppDefaultPadding(
-                  child: PlatformIndependentImage(imageUrl: game.imageUrl)),
-            ]),
+                AppDefaultPadding(child: GameImageWithStats(game: game)),
+                RecommendationsWidget(sourceGame: game, model: model),
+              ]),
+        ),
       ),
     );
   }


### PR DESCRIPTION
…e alignment

Games in the list and recommendations now navigate to an in-app detail page (/game/<name>/<id>) instead of opening BGG externally. The detail page fetches game data via GET /game/:id with the whitelist header and caches responses in-memory for 30 minutes. Share button uses the Web Share API with a copy-link dialog fallback. Game images now align to top when clipped.