### PR TITLE
feat: add rating badge to game image overlay

### DIFF
--- a/lib/components/game_image_with_stats.dart
+++ b/lib/components/game_image_with_stats.dart
@@ -1,3 +1,4 @@
+import 'dart:math' as math;
 import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:how_many_mobile_meeple/components/platform_independent_image.dart';
@@ -25,6 +26,11 @@ class GameImageWithStats extends StatelessWidget with ScreenTools {
                 imageUrl: game.imageUrl,
                 fit: BoxFit.fitWidth,
               ),
+            ),
+            Positioned(
+              right: 8,
+              top: 8,
+              child: _RatingBadge(rating: game.averageRating),
             ),
             Positioned(
               right: 0,
@@ -87,6 +93,148 @@ class GameImageWithStats extends StatelessWidget with ScreenTools {
       ),
     );
   }
+}
+
+class _RatingBadge extends StatelessWidget {
+  final double rating;
+
+  const _RatingBadge({required this.rating});
+
+  @override
+  Widget build(BuildContext context) {
+    final (Color bgColor, Color textColor, Color borderColor, bool isStar) =
+        switch (rating) {
+      >= 7.5 => (
+          const Color(0xFFFFD700),
+          Colors.black,
+          Colors.black,
+          true,
+        ),
+      >= 6.5 => (
+          const Color(0xFFC0C0C0),
+          Colors.black,
+          Colors.black,
+          true,
+        ),
+      >= 5.5 => (
+          const Color(0xFFCD7F32),
+          Colors.white,
+          Colors.black,
+          true,
+        ),
+      >= 4.5 => (
+          Colors.orange,
+          Colors.white,
+          Colors.black,
+          false,
+        ),
+      _ => (
+          Colors.red,
+          Colors.white,
+          Colors.black,
+          false,
+        ),
+    };
+
+    final ratingText = rating.toStringAsFixed(1);
+    const badgeSize = 56.0;
+    final textWidget = Text(
+      ratingText,
+      style: TextStyle(
+        color: textColor,
+        fontSize: 17,
+        fontWeight: FontWeight.w800,
+      ),
+    );
+
+    if (isStar) {
+      return SizedBox(
+        width: badgeSize + 16,
+        height: badgeSize + 16,
+        child: CustomPaint(
+          painter: _StarPainter(fillColor: bgColor, borderColor: borderColor),
+          child: Center(child: textWidget),
+        ),
+      );
+    }
+
+    return Container(
+      width: badgeSize,
+      height: badgeSize,
+      decoration: BoxDecoration(
+        color: bgColor,
+        shape: BoxShape.circle,
+        border: Border.all(color: borderColor, width: 2),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withAlpha(80),
+            blurRadius: 6,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Center(child: textWidget),
+    );
+  }
+}
+
+class _StarPainter extends CustomPainter {
+  final Color fillColor;
+  final Color borderColor;
+
+  _StarPainter({required this.fillColor, required this.borderColor});
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final path = _starPath(size);
+    canvas.drawPath(
+      path,
+      Paint()
+        ..color = fillColor
+        ..style = PaintingStyle.fill,
+    );
+    canvas.drawPath(
+      path,
+      Paint()
+        ..color = borderColor
+        ..style = PaintingStyle.stroke
+        ..strokeWidth = 2,
+    );
+    canvas.drawPath(
+      path,
+      Paint()
+        ..color = Colors.black.withAlpha(80)
+        ..maskFilter = const MaskFilter.blur(BlurStyle.normal, 3)
+        ..style = PaintingStyle.stroke
+        ..strokeWidth = 1,
+    );
+  }
+
+  Path _starPath(Size size) {
+    final cx = size.width / 2;
+    final cy = size.height / 2;
+    final outerRadius = size.width / 2;
+    final innerRadius = outerRadius * 0.45;
+    const points = 5;
+    final path = Path();
+
+    for (var i = 0; i < points * 2; i++) {
+      final radius = i.isEven ? outerRadius : innerRadius;
+      final angle = (i * math.pi / points) - (math.pi / 2);
+      final x = cx + radius * math.cos(angle);
+      final y = cy + radius * math.sin(angle);
+      if (i == 0) {
+        path.moveTo(x, y);
+      } else {
+        path.lineTo(x, y);
+      }
+    }
+    path.close();
+    return path;
+  }
+
+  @override
+  bool shouldRepaint(covariant CustomPainter oldDelegate) => false;
 }
 
 class _StatChip extends StatelessWidget {

--- a/test/components/game_image_with_stats_test.dart
+++ b/test/components/game_image_with_stats_test.dart
@@ -1,0 +1,127 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:how_many_mobile_meeple/components/game_image_with_stats.dart';
+import 'package:how_many_mobile_meeple/model/game.dart';
+
+Game _gameWithRating(double rating) => Game(
+      id: 1,
+      name: 'Test Game',
+      maxPlayers: 4,
+      minPlayers: 2,
+      maxPlaytime: 60,
+      imageUrl: 'http://example.com/test.jpg',
+      averageRating: rating,
+      averageWeight: 2.5,
+    );
+
+Widget _wrapWidget(Widget child) => MaterialApp(
+      home: Scaffold(
+        body: SizedBox(width: 400, height: 600, child: child),
+      ),
+    );
+
+void main() {
+  group('GameImageWithStats rating badge', () {
+    setUp(() {
+      FlutterError.onError = (details) {
+        if (details.toString().contains('overflowed')) return;
+        FlutterError.presentError(details);
+      };
+    });
+
+    tearDown(() {
+      FlutterError.onError = FlutterError.presentError;
+    });
+
+    testWidgets('displays rating text formatted to one decimal place',
+        (tester) async {
+      await tester.pumpWidget(
+        _wrapWidget(GameImageWithStats(game: _gameWithRating(7.83))),
+      );
+
+      expect(find.text('7.8'), findsOneWidget);
+    });
+
+    testWidgets('gold star for rating >= 7.5', (tester) async {
+      await tester.pumpWidget(
+        _wrapWidget(GameImageWithStats(game: _gameWithRating(7.5))),
+      );
+
+      expect(find.text('7.5'), findsOneWidget);
+      final sizedBoxes = find.byWidgetPredicate(
+        (w) => w is SizedBox && w.width == 72 && w.height == 72,
+      );
+      expect(sizedBoxes, findsOneWidget);
+    });
+
+    testWidgets('silver star for rating >= 6.5', (tester) async {
+      await tester.pumpWidget(
+        _wrapWidget(GameImageWithStats(game: _gameWithRating(6.8))),
+      );
+
+      expect(find.text('6.8'), findsOneWidget);
+      final sizedBoxes = find.byWidgetPredicate(
+        (w) => w is SizedBox && w.width == 72 && w.height == 72,
+      );
+      expect(sizedBoxes, findsOneWidget);
+    });
+
+    testWidgets('bronze star for rating >= 5.5', (tester) async {
+      await tester.pumpWidget(
+        _wrapWidget(GameImageWithStats(game: _gameWithRating(5.9))),
+      );
+
+      expect(find.text('5.9'), findsOneWidget);
+      final sizedBoxes = find.byWidgetPredicate(
+        (w) => w is SizedBox && w.width == 72 && w.height == 72,
+      );
+      expect(sizedBoxes, findsOneWidget);
+    });
+
+    testWidgets('orange circle for rating >= 4.5', (tester) async {
+      await tester.pumpWidget(
+        _wrapWidget(GameImageWithStats(game: _gameWithRating(4.7))),
+      );
+
+      expect(find.text('4.7'), findsOneWidget);
+      final containers = find.byWidgetPredicate(
+        (w) =>
+            w is Container &&
+            w.constraints?.maxWidth == 56 &&
+            w.constraints?.maxHeight == 56,
+      );
+      expect(containers, findsOneWidget);
+    });
+
+    testWidgets('red circle for rating < 4.5', (tester) async {
+      await tester.pumpWidget(
+        _wrapWidget(GameImageWithStats(game: _gameWithRating(3.2))),
+      );
+
+      expect(find.text('3.2'), findsOneWidget);
+      final containers = find.byWidgetPredicate(
+        (w) =>
+            w is Container &&
+            w.constraints?.maxWidth == 56 &&
+            w.constraints?.maxHeight == 56,
+      );
+      expect(containers, findsOneWidget);
+    });
+
+    testWidgets('boundary: 7.4 gets silver not gold', (tester) async {
+      await tester.pumpWidget(
+        _wrapWidget(GameImageWithStats(game: _gameWithRating(7.4))),
+      );
+
+      expect(find.text('7.4'), findsOneWidget);
+    });
+
+    testWidgets('boundary: 4.4 gets red not orange', (tester) async {
+      await tester.pumpWidget(
+        _wrapWidget(GameImageWithStats(game: _gameWithRating(4.4))),
+      );
+
+      expect(find.text('4.4'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
Display a color-coded rating badge at the top-right of game images. Gold/silver/bronze stars for ratings >= 7.5/6.5/5.5, orange/red circles for lower ratings.