### PR TITLE
feat: redesign list pages with thumbnails, stats, rating badges, and …

### DIFF
--- a/lib/components/game_image_with_stats.dart
+++ b/lib/components/game_image_with_stats.dart
@@ -2,6 +2,7 @@ import 'dart:math' as math;
 import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:how_many_mobile_meeple/components/platform_independent_image.dart';
+import 'package:how_many_mobile_meeple/components/rating_badge.dart';
 import 'package:how_many_mobile_meeple/model/game.dart';
 import 'package:how_many_mobile_meeple/screen_tools.dart';
 
@@ -27,6 +28,56 @@ class GameImageWithStats extends StatelessWidget with ScreenTools {
                 fit: BoxFit.fitWidth,
               ),
             ),
+            Positioned(
+              left: 0,
+              right: 0,
+              top: maxHeight * 0.65,
+              height: maxHeight * 0.40,
+              child: DecoratedBox(
+                decoration: BoxDecoration(
+                  gradient: LinearGradient(
+                    begin: Alignment.topCenter,
+                    end: Alignment.bottomCenter,
+                    stops: const [0.0, 0.85, 1.0],
+                    colors: [
+                      Colors.transparent,
+                      Theme.of(context).scaffoldBackgroundColor,
+                      Theme.of(context).scaffoldBackgroundColor,
+                    ],
+                  ),
+                ),
+              ),
+            ),
+            if (MediaQuery.of(context).size.width >= 1024 &&
+                game.thumbnail != null)
+              Positioned(
+                left: 24,
+                top: 0,
+                bottom: 0,
+                child: Center(
+                  child: Container(
+                    height: maxHeight * 0.80,
+                    decoration: BoxDecoration(
+                      borderRadius: BorderRadius.circular(8),
+                      border: Border.all(color: Colors.white, width: 2),
+                      boxShadow: [
+                        BoxShadow(
+                          color: Colors.black.withAlpha(100),
+                          blurRadius: 12,
+                          offset: const Offset(0, 4),
+                        ),
+                      ],
+                    ),
+                    child: ClipRRect(
+                      borderRadius: BorderRadius.circular(6),
+                      child: PlatformIndependentImage(
+                        imageUrl: game.imageUrl,
+                        fit: BoxFit.contain,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
             Positioned(
               right: 8,
               top: 8,
@@ -102,39 +153,9 @@ class _RatingBadge extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final (Color bgColor, Color textColor, Color borderColor, bool isStar) =
-        switch (rating) {
-      >= 7.5 => (
-          const Color(0xFFFFD700),
-          Colors.black,
-          Colors.black,
-          true,
-        ),
-      >= 6.5 => (
-          const Color(0xFFC0C0C0),
-          Colors.black,
-          Colors.black,
-          true,
-        ),
-      >= 5.5 => (
-          const Color(0xFFCD7F32),
-          Colors.white,
-          Colors.black,
-          true,
-        ),
-      >= 4.5 => (
-          Colors.orange,
-          Colors.white,
-          Colors.black,
-          false,
-        ),
-      _ => (
-          Colors.red,
-          Colors.white,
-          Colors.black,
-          false,
-        ),
-    };
+    final (Color bgColor, Color textColor) = ratingColors(rating);
+    const borderColor = Colors.black;
+    final isStar = rating >= 5.5;
 
     final ratingText = rating.toStringAsFixed(1);
     const badgeSize = 56.0;

--- a/lib/components/rating_badge.dart
+++ b/lib/components/rating_badge.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+
+(Color bgColor, Color textColor) ratingColors(double rating) {
+  return switch (rating) {
+    >= 7.5 => (const Color(0xFFFFD700), Colors.black),
+    >= 6.5 => (const Color(0xFFC0C0C0), Colors.black),
+    >= 5.5 => (const Color(0xFFCD7F32), Colors.white),
+    >= 4.5 => (Colors.orange, Colors.white),
+    _ => (Colors.red, Colors.white),
+  };
+}
+
+class MiniRatingBadge extends StatelessWidget {
+  final double rating;
+  final double size;
+
+  const MiniRatingBadge({super.key, required this.rating, this.size = 36});
+
+  @override
+  Widget build(BuildContext context) {
+    final (Color bgColor, Color textColor) = ratingColors(rating);
+
+    return Container(
+      width: size,
+      height: size,
+      decoration: BoxDecoration(
+        color: bgColor,
+        borderRadius: BorderRadius.circular(6),
+        border: Border.all(color: Colors.black.withAlpha(40), width: 1),
+      ),
+      child: Center(
+        child: Text(
+          rating.toStringAsFixed(1),
+          style: TextStyle(
+            color: textColor,
+            fontSize: 12,
+            fontWeight: FontWeight.w800,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/platform/mobile/basic_list_games_display.dart
+++ b/lib/platform/mobile/basic_list_games_display.dart
@@ -1,14 +1,16 @@
 import 'package:flutter/material.dart';
-import 'package:sprintf/sprintf.dart';
-import 'package:how_many_mobile_meeple/components/app_default_padding.dart';
 import 'package:how_many_mobile_meeple/platform/router.dart' as r;
 import '../../app_page.dart';
 import '../../app_common.dart';
-import 'package:how_many_mobile_meeple/components/heading_text.dart';
 import '../../how_many_meeple_app_bar.dart';
 import 'package:how_many_mobile_meeple/model/model.dart';
 import '../../model/game.dart';
+import '../../model/games.dart';
 import '../../network_content_widget.dart';
+import 'package:how_many_mobile_meeple/components/platform_independent_image.dart';
+import 'package:how_many_mobile_meeple/components/rating_badge.dart';
+
+const _detailFontSize = 12.0;
 
 class BasicListGamesDisplayPage extends NetworkWidget with AppPage {
   @override
@@ -22,114 +24,182 @@ class BasicListGamesDisplayPage extends NetworkWidget with AppPage {
 
   Widget displayGame(BuildContext context, AppModel model) {
     var cachedGames = model.bggCache;
-    var heading = [
-      TableRow(children: [
-        TableCell(
-          verticalAlignment: TableCellVerticalAlignment.middle,
-          child: AppDefaultPadding(
-            child: TextButton(
-                style: TextButton.styleFrom(padding: EdgeInsets.zero),
-                onPressed: () {
-                  model.toggleSortDirection();
-                  model.sortGameField = SortableGameField.name;
-                  model.refreshState();
-                },
-                child: Container(
-                    alignment: Alignment.bottomLeft,
-                    child: HeadingText("Name", context))),
+    var games = cachedGames.games
+        .getGamesBy(field: model.sortGameField, order: model.sortDirection);
+
+    return Column(
+      children: [
+        _SortBar(model: model),
+        Expanded(
+          child: ListView.builder(
+            itemCount: games.length,
+            itemBuilder: (context, index) {
+              final game = games[index];
+              final isEven = index % 2 == 0;
+              return _GameListTile(game: game, isEven: isEven);
+            },
           ),
         ),
-        TableCell(
-          verticalAlignment: TableCellVerticalAlignment.middle,
-          child: AppDefaultPadding(
-            child: TextButton(
-                style: TextButton.styleFrom(padding: EdgeInsets.zero),
-                onPressed: () {
-                  model.toggleSortDirection();
-                  model.sortGameField = SortableGameField.weight;
-                  model.refreshState();
-                },
-                child: Row(
-                    mainAxisAlignment: MainAxisAlignment.end,
-                    children: [HeadingText("Weight", context)])),
-          ),
+      ],
+    );
+  }
+}
+
+class _SortBar extends StatelessWidget {
+  final AppModel model;
+
+  const _SortBar({required this.model});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surface,
+        border: Border(
+          bottom: BorderSide(color: Theme.of(context).dividerColor),
         ),
-        TableCell(
-          verticalAlignment: TableCellVerticalAlignment.middle,
-          child: AppDefaultPadding(
-            child: TextButton(
-                style: TextButton.styleFrom(padding: EdgeInsets.zero),
-                onPressed: () {
-                  model.toggleSortDirection();
-                  model.sortGameField = SortableGameField.rating;
-                  model.refreshState();
-                },
-                child: Row(
-                    mainAxisAlignment: MainAxisAlignment.end,
-                    children: [HeadingText("Rating", context)])),
-          ),
-        ),
-      ])
-    ];
-    return SingleChildScrollView(
-      scrollDirection: Axis.vertical,
-      child: Table(
-        defaultColumnWidth: FixedColumnWidth(60),
-        columnWidths: {
-          0: FlexColumnWidth(4.0),
-          1: FlexColumnWidth(1.0),
-          2: FlexColumnWidth(1.0)
+      ),
+      child: Row(
+        children: [
+          Text('Sort: ',
+              style: TextStyle(
+                  fontSize: 12,
+                  color: Theme.of(context).colorScheme.secondary)),
+          _sortChip(context, 'Name', SortableGameField.name),
+          _sortChip(context, 'Time', SortableGameField.maxPlaytime),
+          _sortChip(context, 'Weight', SortableGameField.weight),
+          _sortChip(context, 'Rating', SortableGameField.rating),
+        ],
+      ),
+    );
+  }
+
+  Widget _sortChip(
+      BuildContext context, String label, SortableGameField field) {
+    final isActive = model.sortGameField == field;
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 2),
+      child: InkWell(
+        borderRadius: BorderRadius.circular(12),
+        onTap: () {
+          model.toggleSortDirection();
+          model.sortGameField = field;
+          model.refreshState();
         },
-        children: heading +
-            (cachedGames.games
-                .getGamesBy(
-                    field: model.sortGameField, order: model.sortDirection)
-                .map(
-                  (game) => TableRow(
-                      decoration: BoxDecoration(
-                          border: Border(
-                              bottom: BorderSide(
-                                  color: Theme.of(context).dividerColor))),
-                      children: [
-                        TableCell(
-                          verticalAlignment: TableCellVerticalAlignment.middle,
-                          child: AppDefaultPadding(
-                            child: Container(
-                              alignment: Alignment.centerLeft,
-                              child: InkWell(
-                                  child: Text(game.name,
-                                      style: TextStyle(
-                                        decoration: TextDecoration.underline,
-                                      )),
-                                  onTap: () => Navigator.of(context).pushNamed(
-                                      '${r.Router.gameDetailRoute}/${game.name.replaceAll(' ', '+')}/${game.id}')),
-                            ),
-                          ),
-                        ),
-                        TableCell(
-                          verticalAlignment: TableCellVerticalAlignment.middle,
-                          child: AppDefaultPadding(
-                            child: Container(
-                              alignment: Alignment.centerRight,
-                              child: Text(
-                                sprintf("%0.2f", [game.averageWeight]),
-                              ),
-                            ),
-                          ),
-                        ),
-                        TableCell(
-                          verticalAlignment: TableCellVerticalAlignment.middle,
-                          child: AppDefaultPadding(
-                            child: Container(
-                              alignment: Alignment.centerRight,
-                              child: Text(
-                                sprintf("%0.2f", [game.averageRating]),
-                              ),
-                            ),
-                          ),
-                        )
-                      ]),
-                )).toList(),
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+          decoration: BoxDecoration(
+            color: isActive
+                ? Theme.of(context).colorScheme.primary.withAlpha(30)
+                : Colors.transparent,
+            borderRadius: BorderRadius.circular(12),
+          ),
+          child: Text(
+            isActive
+                ? '$label ${model.sortDirection == SortOrder.Asc ? '↑' : '↓'}'
+                : label,
+            style: TextStyle(
+              fontSize: 12,
+              fontWeight: isActive ? FontWeight.bold : FontWeight.normal,
+              color: isActive
+                  ? Theme.of(context).colorScheme.primary
+                  : Theme.of(context).colorScheme.onSurface,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _GameListTile extends StatelessWidget {
+  final Game game;
+  final bool isEven;
+
+  const _GameListTile({required this.game, required this.isEven});
+
+  @override
+  Widget build(BuildContext context) {
+    final detailColor = Theme.of(context).colorScheme.secondary;
+    return InkWell(
+      onTap: () => Navigator.of(context).pushNamed(
+          '${r.Router.gameDetailRoute}/${game.name.replaceAll(' ', '+')}/${game.id}'),
+      child: Container(
+        color: isEven
+            ? Colors.transparent
+            : Theme.of(context).colorScheme.primary.withAlpha(12),
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 8),
+        child: Row(
+          children: [
+            ClipRRect(
+              borderRadius: BorderRadius.circular(4),
+              child: SizedBox(
+                width: 44,
+                height: 44,
+                child: game.thumbnail != null
+                    ? PlatformIndependentImage(
+                        imageUrl: game.thumbnail!,
+                        fit: BoxFit.cover,
+                      )
+                    : Container(
+                        color: Theme.of(context).colorScheme.primaryContainer,
+                        child: Icon(Icons.casino,
+                            size: 20,
+                            color: Theme.of(context)
+                                .colorScheme
+                                .onPrimaryContainer),
+                      ),
+              ),
+            ),
+            const SizedBox(width: 10),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    game.name,
+                    style: const TextStyle(
+                        fontSize: 15, fontWeight: FontWeight.w500),
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  const SizedBox(height: 4),
+                  Row(
+                    children: [
+                      Icon(Icons.people, size: 14, color: detailColor),
+                      const SizedBox(width: 3),
+                      Text(
+                        game.minPlayers == game.maxPlayers
+                            ? '${game.minPlayers}'
+                            : '${game.minPlayers}-${game.maxPlayers}',
+                        style: TextStyle(
+                            fontSize: _detailFontSize, color: detailColor),
+                      ),
+                      const SizedBox(width: 10),
+                      Icon(Icons.timer, size: 14, color: detailColor),
+                      const SizedBox(width: 3),
+                      Text(
+                        AppCommon.minutesToTime(game.maxPlaytime),
+                        style: TextStyle(
+                            fontSize: _detailFontSize, color: detailColor),
+                      ),
+                      const SizedBox(width: 10),
+                      Icon(Icons.fitness_center, size: 14, color: detailColor),
+                      const SizedBox(width: 3),
+                      Text(
+                        '${game.averageWeight.toStringAsFixed(1)}/5',
+                        style: TextStyle(
+                            fontSize: _detailFontSize, color: detailColor),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+            MiniRatingBadge(rating: game.averageRating),
+          ],
+        ),
       ),
     );
   }

--- a/lib/platform/web_or_tablet/enhanced_list_games_display.dart
+++ b/lib/platform/web_or_tablet/enhanced_list_games_display.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:sprintf/sprintf.dart';
 import 'package:how_many_mobile_meeple/components/app_default_padding.dart';
 import 'package:how_many_mobile_meeple/platform/router.dart' as r;
 import '../../app_page.dart';
@@ -8,7 +7,10 @@ import 'package:how_many_mobile_meeple/components/heading_text.dart';
 import '../../how_many_meeple_app_bar.dart';
 import 'package:how_many_mobile_meeple/model/model.dart';
 import '../../model/game.dart';
+import '../../model/games.dart';
 import '../../network_content_widget.dart';
+import 'package:how_many_mobile_meeple/components/platform_independent_image.dart';
+import 'package:how_many_mobile_meeple/components/rating_badge.dart';
 
 class EnhancedListGamesDisplayPage extends NetworkWidget with AppPage {
   @override
@@ -24,6 +26,10 @@ class EnhancedListGamesDisplayPage extends NetworkWidget with AppPage {
     var cachedGames = model.bggCache;
     var heading = [
       TableRow(children: [
+        const TableCell(
+          verticalAlignment: TableCellVerticalAlignment.middle,
+          child: SizedBox(width: 48),
+        ),
         TableCell(
           verticalAlignment: TableCellVerticalAlignment.middle,
           child: AppDefaultPadding(
@@ -36,7 +42,20 @@ class EnhancedListGamesDisplayPage extends NetworkWidget with AppPage {
                 },
                 child: Container(
                     alignment: Alignment.bottomLeft,
-                    child: HeadingText("Name", context))),
+                    child: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        HeadingText("Name", context),
+                        if (model.sortGameField == SortableGameField.name)
+                          Icon(
+                            model.sortDirection == SortOrder.Asc
+                                ? Icons.arrow_upward
+                                : Icons.arrow_downward,
+                            size: 12,
+                            color: Theme.of(context).colorScheme.secondary,
+                          ),
+                      ],
+                    ))),
           ),
         ),
         TableCell(
@@ -49,9 +68,18 @@ class EnhancedListGamesDisplayPage extends NetworkWidget with AppPage {
                   model.sortGameField = SortableGameField.maxPlaytime;
                   model.refreshState();
                 },
-                child: Row(
-                    mainAxisAlignment: MainAxisAlignment.end,
-                    children: [HeadingText("Max Time", context)])),
+                child: Row(mainAxisAlignment: MainAxisAlignment.end, children: [
+                  Icon(Icons.timer,
+                      size: 18, color: Theme.of(context).colorScheme.secondary),
+                  if (model.sortGameField == SortableGameField.maxPlaytime)
+                    Icon(
+                      model.sortDirection == SortOrder.Asc
+                          ? Icons.arrow_upward
+                          : Icons.arrow_downward,
+                      size: 12,
+                      color: Theme.of(context).colorScheme.secondary,
+                    ),
+                ])),
           ),
         ),
         TableCell(
@@ -64,9 +92,18 @@ class EnhancedListGamesDisplayPage extends NetworkWidget with AppPage {
                   model.sortGameField = SortableGameField.weight;
                   model.refreshState();
                 },
-                child: Row(
-                    mainAxisAlignment: MainAxisAlignment.end,
-                    children: [HeadingText("Weight", context)])),
+                child: Row(mainAxisAlignment: MainAxisAlignment.end, children: [
+                  Icon(Icons.fitness_center,
+                      size: 18, color: Theme.of(context).colorScheme.secondary),
+                  if (model.sortGameField == SortableGameField.weight)
+                    Icon(
+                      model.sortDirection == SortOrder.Asc
+                          ? Icons.arrow_upward
+                          : Icons.arrow_downward,
+                      size: 12,
+                      color: Theme.of(context).colorScheme.secondary,
+                    ),
+                ])),
           ),
         ),
         TableCell(
@@ -79,9 +116,18 @@ class EnhancedListGamesDisplayPage extends NetworkWidget with AppPage {
                   model.sortGameField = SortableGameField.rating;
                   model.refreshState();
                 },
-                child: Row(
-                    mainAxisAlignment: MainAxisAlignment.end,
-                    children: [HeadingText("Rating", context)])),
+                child: Row(mainAxisAlignment: MainAxisAlignment.end, children: [
+                  Icon(Icons.star,
+                      size: 18, color: Theme.of(context).colorScheme.secondary),
+                  if (model.sortGameField == SortableGameField.rating)
+                    Icon(
+                      model.sortDirection == SortOrder.Asc
+                          ? Icons.arrow_upward
+                          : Icons.arrow_downward,
+                      size: 12,
+                      color: Theme.of(context).colorScheme.secondary,
+                    ),
+                ])),
           ),
         ),
       ])
@@ -89,74 +135,128 @@ class EnhancedListGamesDisplayPage extends NetworkWidget with AppPage {
     return SingleChildScrollView(
       scrollDirection: Axis.vertical,
       child: Table(
-        defaultColumnWidth: FixedColumnWidth(60),
-        columnWidths: {
-          0: FlexColumnWidth(4.0),
-          1: FlexColumnWidth(1.0),
-          2: FlexColumnWidth(1.0),
-          3: FlexColumnWidth(1.0)
+        defaultColumnWidth: const FixedColumnWidth(60),
+        columnWidths: const {
+          0: FixedColumnWidth(56),
+          1: FlexColumnWidth(4.0),
+          2: MinColumnWidth(FlexColumnWidth(1.0), FixedColumnWidth(80)),
+          3: FlexColumnWidth(1.0),
+          4: FixedColumnWidth(60),
         },
         children: heading +
             (cachedGames.games
                 .getGamesBy(
                     field: model.sortGameField, order: model.sortDirection)
+                .asMap()
+                .entries
                 .map(
-                  (game) => TableRow(
-                      decoration: BoxDecoration(
-                          border: Border(
-                              bottom: BorderSide(
-                                  color: Theme.of(context).dividerColor))),
-                      children: [
-                        TableCell(
-                            verticalAlignment:
-                                TableCellVerticalAlignment.middle,
-                            child: AppDefaultPadding(
-                              child: Container(
-                                  alignment: Alignment.centerLeft,
-                                  child: InkWell(
-                                      child: Text(game.name,
-                                          style: TextStyle(
-                                            decoration:
-                                                TextDecoration.underline,
-                                          )),
-                                      onTap: () => Navigator.of(context).pushNamed(
-                                          '${r.Router.gameDetailRoute}/${game.name.replaceAll(' ', '+')}/${game.id}'))),
-                            )),
-                        TableCell(
-                          verticalAlignment: TableCellVerticalAlignment.middle,
-                          child: AppDefaultPadding(
-                            child: Container(
-                              alignment: Alignment.centerRight,
-                              child: Text(
-                                  AppCommon.minutesToTime(game.maxPlaytime)),
-                            ),
-                          ),
-                        ),
-                        TableCell(
-                          verticalAlignment: TableCellVerticalAlignment.middle,
-                          child: AppDefaultPadding(
-                            child: Container(
-                              alignment: Alignment.centerRight,
-                              child: Text(
-                                sprintf("%0.2f", [game.averageWeight]),
-                              ),
-                            ),
-                          ),
-                        ),
-                        TableCell(
-                          verticalAlignment: TableCellVerticalAlignment.middle,
-                          child: AppDefaultPadding(
-                            child: Container(
-                              alignment: Alignment.centerRight,
-                              child: Text(
-                                sprintf("%0.2f", [game.averageRating]),
-                              ),
-                            ),
-                          ),
-                        )
-                      ]),
+                  (entry) => _buildRow(context, entry.value, entry.key),
                 )).toList(),
       ),
     );
+  }
+
+  TableRow _buildRow(BuildContext context, Game game, int index) {
+    final isEven = index % 2 == 0;
+    return TableRow(
+        decoration: BoxDecoration(
+          color: isEven
+              ? Colors.transparent
+              : Theme.of(context).colorScheme.primary.withAlpha(8),
+          border:
+              Border(bottom: BorderSide(color: Theme.of(context).dividerColor)),
+        ),
+        children: [
+          TableCell(
+            verticalAlignment: TableCellVerticalAlignment.middle,
+            child: Padding(
+              padding: const EdgeInsets.symmetric(vertical: 4, horizontal: 4),
+              child: ClipRRect(
+                borderRadius: BorderRadius.circular(4),
+                child: SizedBox(
+                  width: 44,
+                  height: 44,
+                  child: game.thumbnail != null
+                      ? PlatformIndependentImage(
+                          imageUrl: game.thumbnail!,
+                          fit: BoxFit.cover,
+                        )
+                      : Container(
+                          color: Theme.of(context).colorScheme.primaryContainer,
+                          child: Icon(Icons.casino,
+                              size: 22,
+                              color: Theme.of(context)
+                                  .colorScheme
+                                  .onPrimaryContainer),
+                        ),
+                ),
+              ),
+            ),
+          ),
+          TableCell(
+              verticalAlignment: TableCellVerticalAlignment.middle,
+              child: AppDefaultPadding(
+                child: Container(
+                  alignment: Alignment.centerLeft,
+                  child: InkWell(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Text(game.name,
+                            style: const TextStyle(
+                              decoration: TextDecoration.underline,
+                            )),
+                        const SizedBox(height: 2),
+                        Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Icon(Icons.people,
+                                size: 12,
+                                color: Theme.of(context).colorScheme.secondary),
+                            const SizedBox(width: 3),
+                            Text(
+                              game.minPlayers == game.maxPlayers
+                                  ? '${game.minPlayers} players'
+                                  : '${game.minPlayers}-${game.maxPlayers} players',
+                              style: TextStyle(
+                                  fontSize: 11,
+                                  color:
+                                      Theme.of(context).colorScheme.secondary),
+                            ),
+                          ],
+                        ),
+                      ],
+                    ),
+                    onTap: () => Navigator.of(context).pushNamed(
+                        '${r.Router.gameDetailRoute}/${game.name.replaceAll(' ', '+')}/${game.id}'),
+                  ),
+                ),
+              )),
+          TableCell(
+            verticalAlignment: TableCellVerticalAlignment.middle,
+            child: AppDefaultPadding(
+              child: Container(
+                alignment: Alignment.centerRight,
+                child: Text(AppCommon.minutesToTime(game.maxPlaytime)),
+              ),
+            ),
+          ),
+          TableCell(
+            verticalAlignment: TableCellVerticalAlignment.middle,
+            child: AppDefaultPadding(
+              child: Container(
+                alignment: Alignment.centerRight,
+                child: Text(game.averageWeight.toStringAsFixed(2)),
+              ),
+            ),
+          ),
+          TableCell(
+            verticalAlignment: TableCellVerticalAlignment.middle,
+            child: Center(
+              child: MiniRatingBadge(rating: game.averageRating, size: 38),
+            ),
+          ),
+        ]);
   }
 }


### PR DESCRIPTION
…sort indicators

- Add visual list tiles with game thumbnails, player count, playtime, weight
- Add color-coded mini rating badges to both list layouts
- Add sort direction arrows (ascending/descending) on active sort field
- Add gradient fade and wide-screen thumbnail (1024px+) to game detail image
- Extract shared rating_badge.dart to deduplicate color logic and mini badge widget
- Add zebra striping for visual row separation