### PR TITLE
feat: cache drawer preferences and hide empty game stats

### DIFF
--- a/lib/app_page.dart
+++ b/lib/app_page.dart
@@ -140,7 +140,7 @@ mixin AppPage {
   Future<List<Widget>> drawerFilters(
       BuildContext context, AppModel model) async {
     var drawerSettingsColumn =
-        await ComponentFactory.getDrawerSettingsColumn(AppCommon.savedSettings);
+        ComponentFactory.getDrawerSettingsColumn(AppCommon.savedSettings);
     final staticFiltersList = staticFilters(model, context);
     final allFilters = <Widget>[drawerHeader(context)] +
         staticFiltersList +

--- a/lib/components/component_factory.dart
+++ b/lib/components/component_factory.dart
@@ -1,10 +1,7 @@
-import 'package:how_many_mobile_meeple/storage/storage_factory.dart';
 import 'drawer_settings_column.dart';
 
 abstract class ComponentFactory {
-  static Future<DrawerSettingsColumn> getDrawerSettingsColumn(
-      String drawerName) async {
-    return DrawerSettingsColumn(drawerName,
-        historyDb: StorageFactory.getPreferencesHistory());
+  static DrawerSettingsColumn getDrawerSettingsColumn(String drawerName) {
+    return DrawerSettingsColumn(drawerName);
   }
 }

--- a/lib/components/drawer_saved_setting.dart
+++ b/lib/components/drawer_saved_setting.dart
@@ -70,7 +70,7 @@ class DrawerSavedSetting extends Container {
                   var model = AppModel.of(context, listen: false);
                   var db = StorageFactory.getPreferencesHistory();
                   db.deletePreference(preferences.id!);
-                  model.refreshState();
+                  model.invalidatePreferencesCache();
                 },
               ),
             ],

--- a/lib/components/drawer_settings_column.dart
+++ b/lib/components/drawer_settings_column.dart
@@ -1,27 +1,26 @@
 import 'package:flutter/cupertino.dart';
 import 'package:how_many_mobile_meeple/model/app_preferences.dart';
 import 'package:how_many_mobile_meeple/model/model.dart';
-import 'package:how_many_mobile_meeple/storage/preferences_history_interface.dart';
 
 import 'drawer_heading.dart';
 import 'drawer_saved_setting.dart';
 
 class DrawerSettingsColumn {
-  final PreferencesHistoryInterface historyDb;
   final String drawerName;
 
-  DrawerSettingsColumn(this.drawerName, {required this.historyDb});
+  DrawerSettingsColumn(this.drawerName);
 
   Future<List<Widget>> drawerContent(
       BuildContext context, AppModel model, int startIndex) async {
     List<Widget> fixedDrawerItems = [DrawerHeading(drawerName, context)];
-    List<Widget> dynamicDrawerItems = await settingsFromDb(context, startIndex);
+    List<Widget> dynamicDrawerItems =
+        await settingsFromModel(context, model, startIndex);
     return fixedDrawerItems + dynamicDrawerItems;
   }
 
-  Future<List<DrawerSavedSetting>> settingsFromDb(
-      BuildContext context, int startIndex) async {
-    List<AppPreferences> settings = await historyDb.loadAllPreferences();
+  Future<List<DrawerSavedSetting>> settingsFromModel(
+      BuildContext context, AppModel model, int startIndex) async {
+    List<AppPreferences> settings = await model.getSavedPreferences();
     return settings
         .asMap()
         .entries

--- a/lib/components/game_image_with_stats.dart
+++ b/lib/components/game_image_with_stats.dart
@@ -11,6 +11,12 @@ class GameImageWithStats extends StatelessWidget with ScreenTools {
 
   GameImageWithStats({super.key, required this.game});
 
+  bool get _hasImage => game.imageUrl.isNotEmpty;
+  bool get _hasRating => game.averageRating > 0;
+  bool get _hasPlayers => game.minPlayers > 0 || game.maxPlayers > 0;
+  bool get _hasPlaytime => game.maxPlaytime > 0;
+  bool get _hasWeight => game.averageWeight > 0;
+
   @override
   Widget build(BuildContext context) {
     final maxHeight = getScreenHeightPercentageInPixels(
@@ -21,34 +27,37 @@ class GameImageWithStats extends StatelessWidget with ScreenTools {
         child: Stack(
           clipBehavior: Clip.hardEdge,
           children: [
-            SizedBox(
-              width: double.infinity,
-              child: PlatformIndependentImage(
-                imageUrl: game.imageUrl,
-                fit: BoxFit.fitWidth,
+            if (_hasImage)
+              SizedBox(
+                width: double.infinity,
+                child: PlatformIndependentImage(
+                  imageUrl: game.imageUrl,
+                  fit: BoxFit.fitWidth,
+                ),
               ),
-            ),
-            Positioned(
-              left: 0,
-              right: 0,
-              top: maxHeight * 0.65,
-              height: maxHeight * 0.40,
-              child: DecoratedBox(
-                decoration: BoxDecoration(
-                  gradient: LinearGradient(
-                    begin: Alignment.topCenter,
-                    end: Alignment.bottomCenter,
-                    stops: const [0.0, 0.85, 1.0],
-                    colors: [
-                      Colors.transparent,
-                      Theme.of(context).scaffoldBackgroundColor,
-                      Theme.of(context).scaffoldBackgroundColor,
-                    ],
+            if (_hasImage)
+              Positioned(
+                left: 0,
+                right: 0,
+                top: maxHeight * 0.65,
+                height: maxHeight * 0.40,
+                child: DecoratedBox(
+                  decoration: BoxDecoration(
+                    gradient: LinearGradient(
+                      begin: Alignment.topCenter,
+                      end: Alignment.bottomCenter,
+                      stops: const [0.0, 0.85, 1.0],
+                      colors: [
+                        Colors.transparent,
+                        Theme.of(context).scaffoldBackgroundColor,
+                        Theme.of(context).scaffoldBackgroundColor,
+                      ],
+                    ),
                   ),
                 ),
               ),
-            ),
-            if (MediaQuery.of(context).size.width >= 1024 &&
+            if (_hasImage &&
+                MediaQuery.of(context).size.width >= 1024 &&
                 game.thumbnail != null)
               Positioned(
                 left: 24,
@@ -78,11 +87,12 @@ class GameImageWithStats extends StatelessWidget with ScreenTools {
                   ),
                 ),
               ),
-            Positioned(
-              right: 8,
-              top: 8,
-              child: _RatingBadge(rating: game.averageRating),
-            ),
+            if (_hasRating)
+              Positioned(
+                right: 8,
+                top: 8,
+                child: _RatingBadge(rating: game.averageRating),
+              ),
             Positioned(
               right: 0,
               bottom: 0,
@@ -107,23 +117,29 @@ class GameImageWithStats extends StatelessWidget with ScreenTools {
                   crossAxisAlignment: CrossAxisAlignment.start,
                   mainAxisSize: MainAxisSize.min,
                   children: [
-                    _StatChip(
-                      icon: Icons.people,
-                      label: game.minPlayers == game.maxPlayers
-                          ? '${game.minPlayers} players'
-                          : '${game.minPlayers}-${game.maxPlayers} players',
-                    ),
-                    const SizedBox(height: 14),
-                    _StatChip(
-                      icon: Icons.timer,
-                      label: '${game.maxPlaytime} min',
-                    ),
-                    const SizedBox(height: 14),
-                    _StatChip(
-                      icon: Icons.fitness_center,
-                      label: '${game.averageWeight.toStringAsFixed(1)} / 5',
-                    ),
-                    const SizedBox(height: 14),
+                    if (_hasPlayers) ...[
+                      _StatChip(
+                        icon: Icons.people,
+                        label: game.minPlayers == game.maxPlayers
+                            ? '${game.minPlayers} players'
+                            : '${game.minPlayers}-${game.maxPlayers} players',
+                      ),
+                      const SizedBox(height: 14),
+                    ],
+                    if (_hasPlaytime) ...[
+                      _StatChip(
+                        icon: Icons.timer,
+                        label: '${game.maxPlaytime} min',
+                      ),
+                      const SizedBox(height: 14),
+                    ],
+                    if (_hasWeight) ...[
+                      _StatChip(
+                        icon: Icons.fitness_center,
+                        label: '${game.averageWeight.toStringAsFixed(1)} / 5',
+                      ),
+                      const SizedBox(height: 14),
+                    ],
                     MouseRegion(
                       cursor: SystemMouseCursors.click,
                       child: GestureDetector(

--- a/lib/model/model.dart
+++ b/lib/model/model.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/cupertino.dart';
 import 'package:how_many_mobile_meeple/platform/web/url_fragment_extractor.dart';
+import 'package:how_many_mobile_meeple/storage/preferences_history_interface.dart';
 import 'package:how_many_mobile_meeple/storage/storage_factory.dart';
 import 'package:how_many_mobile_meeple/storage/stored_preferences.dart';
 import 'package:provider/provider.dart';
 import 'package:how_many_mobile_meeple/model/settings.dart';
 
+import 'package:how_many_mobile_meeple/model/app_preferences.dart';
 import 'package:how_many_mobile_meeple/model/bgg_cache.dart';
 import 'package:how_many_mobile_meeple/model/game_request.dart';
 import 'package:how_many_mobile_meeple/model/item.dart';
@@ -28,9 +30,12 @@ class AppModel extends ChangeNotifier {
 
   String? title;
 
+  final PreferencesHistoryInterface _preferencesHistory;
+
   Items _items = Items([]);
   BggCache _bggCache = BggCache(Games(), _unsetCacheDurationInMinutes);
   StoredPreferences? _store;
+  List<AppPreferences>? _cachedPreferences;
 
   late Settings _settings;
   Orientation? screenOrientation;
@@ -47,7 +52,9 @@ class AppModel extends ChangeNotifier {
 
   UrlFragmentExtractor _extractor = UrlFragmentExtractor(Uri.base);
 
-  AppModel() {
+  AppModel({PreferencesHistoryInterface? preferencesHistory})
+      : _preferencesHistory =
+            preferencesHistory ?? StorageFactory.getPreferencesHistory() {
     _settings = Settings.defaultSettings();
   }
 
@@ -131,6 +138,16 @@ class AppModel extends ChangeNotifier {
       _storeSettings(settings),
       _storeItems(_items),
     ]);
+    notifyListeners();
+  }
+
+  Future<List<AppPreferences>> getSavedPreferences() async {
+    _cachedPreferences ??= await _preferencesHistory.loadAllPreferences();
+    return _cachedPreferences!;
+  }
+
+  void invalidatePreferencesCache() {
+    _cachedPreferences = null;
     notifyListeners();
   }
 

--- a/lib/save_dialog.dart
+++ b/lib/save_dialog.dart
@@ -110,7 +110,7 @@ class SaveDialog extends StatelessWidget {
                           model.title = controller.text;
                           history
                               .storePreference(AppPreferences.fromModel(model));
-                          model.refreshState();
+                          model.invalidatePreferencesCache();
                           Navigator.pop(context);
                         },
                         icon: const Icon(Icons.save),

--- a/test/components/game_image_with_stats_test.dart
+++ b/test/components/game_image_with_stats_test.dart
@@ -14,6 +14,28 @@ Game _gameWithRating(double rating) => Game(
       averageWeight: 2.5,
     );
 
+Game _gameWithNoData() => Game(
+      id: 1,
+      name: 'Mystery Game',
+      maxPlayers: 0,
+      minPlayers: 0,
+      maxPlaytime: 0,
+      imageUrl: '',
+      averageRating: 0,
+      averageWeight: 0,
+    );
+
+Game _gameWithPartialData() => Game(
+      id: 1,
+      name: 'Partial Game',
+      maxPlayers: 4,
+      minPlayers: 2,
+      maxPlaytime: 0,
+      imageUrl: 'http://example.com/test.jpg',
+      averageRating: 7.5,
+      averageWeight: 0,
+    );
+
 Widget _wrapWidget(Widget child) => MaterialApp(
       home: Scaffold(
         body: SizedBox(width: 400, height: 600, child: child),
@@ -122,6 +144,71 @@ void main() {
       );
 
       expect(find.text('4.4'), findsOneWidget);
+    });
+  });
+
+  group('GameImageWithStats hides missing data', () {
+    setUp(() {
+      FlutterError.onError = (details) {
+        if (details.toString().contains('overflowed')) return;
+        FlutterError.presentError(details);
+      };
+    });
+
+    tearDown(() {
+      FlutterError.onError = FlutterError.presentError;
+    });
+
+    testWidgets('hides rating badge when rating is 0', (tester) async {
+      await tester.pumpWidget(
+        _wrapWidget(GameImageWithStats(game: _gameWithNoData())),
+      );
+
+      expect(find.text('0.0'), findsNothing);
+    });
+
+    testWidgets('hides player count when both min and max are 0',
+        (tester) async {
+      await tester.pumpWidget(
+        _wrapWidget(GameImageWithStats(game: _gameWithNoData())),
+      );
+
+      expect(find.byIcon(Icons.people), findsNothing);
+    });
+
+    testWidgets('hides playtime when maxPlaytime is 0', (tester) async {
+      await tester.pumpWidget(
+        _wrapWidget(GameImageWithStats(game: _gameWithNoData())),
+      );
+
+      expect(find.byIcon(Icons.timer), findsNothing);
+    });
+
+    testWidgets('hides weight when averageWeight is 0', (tester) async {
+      await tester.pumpWidget(
+        _wrapWidget(GameImageWithStats(game: _gameWithNoData())),
+      );
+
+      expect(find.byIcon(Icons.fitness_center), findsNothing);
+    });
+
+    testWidgets('always shows BoardGameGeek link', (tester) async {
+      await tester.pumpWidget(
+        _wrapWidget(GameImageWithStats(game: _gameWithNoData())),
+      );
+
+      expect(find.text('BoardGameGeek'), findsOneWidget);
+    });
+
+    testWidgets('shows only stats that have data', (tester) async {
+      await tester.pumpWidget(
+        _wrapWidget(GameImageWithStats(game: _gameWithPartialData())),
+      );
+
+      expect(find.byIcon(Icons.people), findsOneWidget);
+      expect(find.byIcon(Icons.timer), findsNothing);
+      expect(find.byIcon(Icons.fitness_center), findsNothing);
+      expect(find.text('BoardGameGeek'), findsOneWidget);
     });
   });
 }

--- a/test/model/app_model_preferences_test.dart
+++ b/test/model/app_model_preferences_test.dart
@@ -1,0 +1,109 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:how_many_mobile_meeple/model/app_preferences.dart';
+import 'package:how_many_mobile_meeple/model/items.dart';
+import 'package:how_many_mobile_meeple/model/model.dart';
+import 'package:how_many_mobile_meeple/model/settings.dart';
+import 'package:how_many_mobile_meeple/storage/preferences_history_interface.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class MockPreferencesHistory implements PreferencesHistoryInterface {
+  int loadAllCallCount = 0;
+  List<AppPreferences> _preferences = [];
+
+  void setPreferences(List<AppPreferences> prefs) {
+    _preferences = prefs;
+  }
+
+  @override
+  Future<List<AppPreferences>> loadAllPreferences() async {
+    loadAllCallCount++;
+    return List.from(_preferences);
+  }
+
+  @override
+  Future<void> storePreference(AppPreferences preferences) async {
+    _preferences.add(preferences);
+  }
+
+  @override
+  Future<AppPreferences> loadPreference(int preferenceId) async {
+    return _preferences.firstWhere((p) => p.id == preferenceId.toString());
+  }
+
+  @override
+  Future<bool> deletePreference(String preferenceId) async {
+    _preferences.removeWhere((p) => p.id == preferenceId);
+    return true;
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  group('AppModel.getSavedPreferences', () {
+    test('loads from history on first call', () async {
+      final mock = MockPreferencesHistory();
+      mock.setPreferences([
+        AppPreferences('1', 'Test', Items([]), Settings.defaultSettings()),
+      ]);
+      final model = AppModel(preferencesHistory: mock);
+
+      final result = await model.getSavedPreferences();
+
+      expect(result.length, 1);
+      expect(result.first.title, 'Test');
+      expect(mock.loadAllCallCount, 1);
+    });
+
+    test('returns cached results on subsequent calls', () async {
+      final mock = MockPreferencesHistory();
+      mock.setPreferences([
+        AppPreferences('1', 'Test', Items([]), Settings.defaultSettings()),
+      ]);
+      final model = AppModel(preferencesHistory: mock);
+
+      await model.getSavedPreferences();
+      await model.getSavedPreferences();
+      await model.getSavedPreferences();
+
+      expect(mock.loadAllCallCount, 1);
+    });
+
+    test('reloads from history after invalidatePreferencesCache', () async {
+      final mock = MockPreferencesHistory();
+      mock.setPreferences([
+        AppPreferences('1', 'First', Items([]), Settings.defaultSettings()),
+      ]);
+      final model = AppModel(preferencesHistory: mock);
+
+      final first = await model.getSavedPreferences();
+      expect(first.length, 1);
+      expect(mock.loadAllCallCount, 1);
+
+      mock.setPreferences([
+        AppPreferences('1', 'First', Items([]), Settings.defaultSettings()),
+        AppPreferences('2', 'Second', Items([]), Settings.defaultSettings()),
+      ]);
+
+      model.invalidatePreferencesCache();
+
+      final second = await model.getSavedPreferences();
+      expect(second.length, 2);
+      expect(mock.loadAllCallCount, 2);
+    });
+
+    test('returns empty list when no preferences exist', () async {
+      final mock = MockPreferencesHistory();
+      final model = AppModel(preferencesHistory: mock);
+
+      final result = await model.getSavedPreferences();
+
+      expect(result, isEmpty);
+      expect(mock.loadAllCallCount, 1);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- **#28** — Caches saved preferences in `AppModel` via injected `PreferencesHistoryInterface`. Opening the drawer no longer triggers a DB query each time — only on first load or after a save/delete invalidates the cache.
- **#64** — Hides rating badge, player count, playtime, weight, and image on game detail/random pages when data is missing (e.g. older BGG games with no stats). The BoardGameGeek link always remains visible.

## Changes
- DI refactor: `AppModel` accepts optional `PreferencesHistoryInterface` (defaults to `StorageFactory.getPreferencesHistory()`)
- `DrawerSettingsColumn` reads from model cache instead of direct DB
- `ComponentFactory.getDrawerSettingsColumn` simplified to synchronous
- `GameImageWithStats` conditionally renders stats only when non-zero
- 10 new tests (4 for preferences caching, 6 for stats visibility)

## Test plan
- [x] Open drawer multiple times — confirm no lag/flicker from repeated DB hits
- [x] Save a preference, reopen drawer — confirm it appears
- [x] Delete a preference, reopen drawer — confirm it's gone
- [x] View a game with full data (e.g. Wingspan) — all stats visible
- [x] View a game with no data (e.g. Endeavor: Deep Sea from /hot) — only BGG link shown, no "0 players" or broken image
- [x] Run `flutter test` — all 118 tests pass

Closes #28
Closes #64