### PR TITLE
feat: Quick Pick for fast random game selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Have an idea for a feature that you think will make this app amazing?  Feel free
 
 ## Contributors
 
-- [@SWH30](https://github.com/SWH30)
+- [@oldstevekenobi](https://github.com/oldstevekenobi)
 - [@Teqqles](https://github.com/teqqles)
 - [@tjforryan](https://github.com/tjforryan)
 

--- a/lib/about_page.dart
+++ b/lib/about_page.dart
@@ -227,10 +227,10 @@ class AboutPage extends StatelessWidget {
 
   Widget _buildContributors(BuildContext context) {
     const contributors = [
-      {'name': 'David Long', 'github': 'Teqqles'},
-      {'name': 'DragonC', 'github': 'DragonC'},
-      {'name': 'SWH30', 'github': 'SWH30'},
-      {'name': 'tjforryan', 'github': 'tjforryan'},
+      {'name': 'David Long', 'url': 'https://github.com/Teqqles'},
+      {'name': 'DragonC', 'url': 'https://boardgamegeek.com/profile/DragonC'},
+      {'name': 'Steve Whalley', 'url': 'https://github.com/oldstevekenobi'},
+      {'name': 'tjforryan', 'url': 'https://github.com/tjforryan'},
     ];
 
     return Card(
@@ -249,8 +249,7 @@ class AboutPage extends StatelessWidget {
             ...contributors.map((c) => Padding(
                   padding: const EdgeInsets.only(bottom: 6),
                   child: InkWell(
-                    onTap: () =>
-                        _launchUrl('https://github.com/${c['github']}'),
+                    onTap: () => _launchUrl(c['url']!),
                     child: Row(
                       children: [
                         Icon(Icons.person_outline,

--- a/lib/app_page.dart
+++ b/lib/app_page.dart
@@ -6,6 +6,7 @@ import 'package:provider/provider.dart';
 import 'package:how_many_mobile_meeple/components/drawer_bgg_filter.dart';
 import 'package:how_many_mobile_meeple/components/drawer_switch.dart';
 import 'package:how_many_mobile_meeple/components/app_default_padding.dart';
+import 'package:how_many_mobile_meeple/components/quick_pick_sheet.dart';
 import 'app_common.dart';
 import 'components/component_factory.dart';
 import 'model/game.dart';
@@ -201,31 +202,51 @@ mixin AppPage {
     AppModel.of(context, listen: false).refreshFromUrl();
   }
 
+  Widget _floatingIconButton(
+    BuildContext context, {
+    required IconData icon,
+    required String tooltip,
+    required VoidCallback onPressed,
+  }) {
+    return Container(
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.secondary,
+        borderRadius: BorderRadius.circular(40.0),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(5),
+        child: IconButton(
+          padding: const EdgeInsets.all(0),
+          color: Theme.of(context).selectedRowColor,
+          tooltip: tooltip,
+          icon: Icon(icon, size: 36),
+          onPressed: onPressed,
+        ),
+      ),
+    );
+  }
+
   Widget iconButtonGroup(BuildContext context) => Row(
         mainAxisAlignment: MainAxisAlignment.end,
         crossAxisAlignment: CrossAxisAlignment.end,
         children: <Widget>[
-          Container(
-            decoration: BoxDecoration(
-              color: Theme.of(context).colorScheme.secondary,
-              borderRadius: BorderRadius.circular(40.0),
-            ),
-            child: Padding(
-              padding:
-                  const EdgeInsets.only(left: 5, right: 5, top: 5, bottom: 5),
-              child: IconButton(
-                  padding: const EdgeInsets.all(0),
-                  color: Theme.of(context).selectedRowColor,
-                  icon: Icon(
-                    Icons.format_list_numbered,
-                    size: 36,
-                  ),
-                  onPressed: () {
-                    var listPageSettings = r.Router.generateRouteSettings(
-                        r.Router.listRoute,
-                        AppModel.of(context, listen: false));
-                    loadPage(context, listPageSettings);
-                  }),
+          _floatingIconButton(
+            context,
+            icon: Icons.format_list_numbered,
+            tooltip: 'View List',
+            onPressed: () {
+              var listPageSettings = r.Router.generateRouteSettings(
+                  r.Router.listRoute, AppModel.of(context, listen: false));
+              loadPage(context, listPageSettings);
+            },
+          ),
+          Padding(
+            padding: const EdgeInsets.only(left: 8),
+            child: _floatingIconButton(
+              context,
+              icon: Icons.bolt,
+              tooltip: 'Quick Pick',
+              onPressed: () => QuickPickSheet.show(context),
             ),
           ),
           Padding(
@@ -271,9 +292,12 @@ mixin AppPage {
 
   ElevatedButton shareButton(BuildContext context, Game game) {
     return ElevatedButton(
-      child: Icon(
-        Icons.share,
-        color: Theme.of(context).selectedRowColor,
+      child: Tooltip(
+        message: 'Share',
+        child: Icon(
+          Icons.share,
+          color: Theme.of(context).selectedRowColor,
+        ),
       ),
       onPressed: () async {
         final baseUri = Uri.base.removeFragment();

--- a/lib/components/app_choice_chip.dart
+++ b/lib/components/app_choice_chip.dart
@@ -1,0 +1,112 @@
+import 'package:flutter/material.dart';
+
+class AppChoiceChip extends StatelessWidget {
+  final String label;
+  final bool selected;
+  final ValueChanged<bool>? onSelected;
+  final Widget? avatar;
+
+  const AppChoiceChip({
+    super.key,
+    required this.label,
+    required this.selected,
+    required this.onSelected,
+    this.avatar,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return ChoiceChip(
+      label: Text(label),
+      selected: selected,
+      showCheckmark: false,
+      avatar: avatar,
+      onSelected: onSelected,
+      selectedColor: Theme.of(context).colorScheme.secondary,
+      backgroundColor: Theme.of(context).colorScheme.surfaceContainerHighest,
+      labelStyle: TextStyle(
+        color: selected
+            ? Theme.of(context).colorScheme.onSecondary
+            : Theme.of(context).colorScheme.onSurface,
+        fontWeight: selected ? FontWeight.bold : FontWeight.normal,
+      ),
+    );
+  }
+}
+
+class AppFilterChip extends StatelessWidget {
+  final String label;
+  final bool selected;
+  final ValueChanged<bool>? onSelected;
+  final Widget? avatar;
+
+  const AppFilterChip({
+    super.key,
+    required this.label,
+    required this.selected,
+    required this.onSelected,
+    this.avatar,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return FilterChip(
+      label: Text(label),
+      selected: selected,
+      showCheckmark: false,
+      avatar: avatar,
+      onSelected: onSelected,
+      selectedColor: Theme.of(context).colorScheme.secondary,
+      backgroundColor: Theme.of(context).colorScheme.surfaceContainerHighest,
+      labelStyle: TextStyle(
+        color: selected
+            ? Theme.of(context).colorScheme.onSecondary
+            : Theme.of(context).colorScheme.onSurface,
+        fontWeight: selected ? FontWeight.bold : FontWeight.normal,
+      ),
+    );
+  }
+}
+
+class AppMechanicChip extends StatelessWidget {
+  final String label;
+  final bool selected;
+  final bool enabled;
+  final ValueChanged<bool>? onSelected;
+
+  const AppMechanicChip({
+    super.key,
+    required this.label,
+    required this.selected,
+    this.enabled = true,
+    required this.onSelected,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return ChoiceChip(
+      label: Text(label),
+      selected: selected,
+      onSelected: enabled ? onSelected : null,
+      selectedColor: Theme.of(context).colorScheme.secondary,
+      disabledColor: Colors.grey[100],
+      backgroundColor: enabled ? Colors.grey[200] : Colors.grey[100],
+      elevation: enabled ? 2 : 0,
+      side: BorderSide(
+        color: enabled
+            ? (selected
+                ? Theme.of(context).colorScheme.secondary
+                : Colors.grey[400]!)
+            : Colors.grey[300]!,
+        width: 1.5,
+      ),
+      labelStyle: TextStyle(
+        fontSize: 12,
+        fontWeight: FontWeight.bold,
+        color: selected && enabled
+            ? Colors.white
+            : (enabled ? Colors.black87 : Theme.of(context).disabledColor),
+      ),
+    );
+  }
+}

--- a/lib/components/board_game_item_list_widget.dart
+++ b/lib/components/board_game_item_list_widget.dart
@@ -63,6 +63,7 @@ class BoardGameItemListWidget extends StatelessWidget {
         trailing: IconButton(
           padding: const EdgeInsets.all(4),
           constraints: const BoxConstraints(),
+          tooltip: 'Remove',
           icon: Icon(
             Icons.delete,
             size: AppCommon.standardIconSize,

--- a/lib/components/drawer_saved_setting.dart
+++ b/lib/components/drawer_saved_setting.dart
@@ -54,6 +54,7 @@ class DrawerSavedSetting extends Container {
                 }, // id},
               ),
               IconButton(
+                tooltip: 'Delete',
                 icon: Icon(
                   Icons.delete,
                   size: AppCommon.standardIconSize,

--- a/lib/components/mechanic_filter_widget.dart
+++ b/lib/components/mechanic_filter_widget.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:how_many_mobile_meeple/app_common.dart';
+import 'package:how_many_mobile_meeple/components/app_choice_chip.dart';
 import 'package:how_many_mobile_meeple/components/toggleable_homepage_menu_item_widget.dart';
 import 'package:how_many_mobile_meeple/model/mechanics.dart';
 import 'package:how_many_mobile_meeple/model/model.dart';
@@ -36,31 +37,11 @@ class MechanicFilterWidget extends StatelessWidget {
                   final isEnabled = model.settings
                       .setting(Settings.filterMechanics.name)
                       .enabled;
-                  return ChoiceChip(
-                    labelStyle: TextStyle(
-                        fontSize: 12,
-                        fontWeight: FontWeight.bold,
-                        color: isSelected && isEnabled
-                            ? Colors.white
-                            : (isEnabled
-                                ? Colors.black87
-                                : Theme.of(context).disabledColor)),
-                    backgroundColor:
-                        isEnabled ? Colors.grey[200] : Colors.grey[100],
-                    selectedColor: Theme.of(context).colorScheme.secondary,
-                    disabledColor: Colors.grey[100],
-                    elevation: isEnabled ? 2 : 0,
-                    side: BorderSide(
-                        color: isEnabled
-                            ? (isSelected
-                                ? Theme.of(context).colorScheme.secondary
-                                : Colors.grey[400]!)
-                            : Colors.grey[300]!,
-                        width: 1.5),
-                    label: Text(value),
+                  return AppMechanicChip(
+                    label: value,
                     selected: isSelected,
+                    enabled: isEnabled,
                     onSelected: (bool selected) {
-                      if (!isEnabled) return;
                       selected
                           ? model.settings
                               .setting(Settings.filterMechanics.name)

--- a/lib/components/quick_pick_sheet.dart
+++ b/lib/components/quick_pick_sheet.dart
@@ -1,0 +1,253 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:how_many_mobile_meeple/components/app_choice_chip.dart';
+import 'package:how_many_mobile_meeple/model/model.dart';
+import 'package:how_many_mobile_meeple/model/settings.dart';
+import 'package:how_many_mobile_meeple/platform/router.dart' as r;
+
+class QuickPickSheet extends StatefulWidget {
+  const QuickPickSheet({super.key});
+
+  static void show(BuildContext context) {
+    showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      builder: (_) => const QuickPickSheet(),
+    );
+  }
+
+  @override
+  State<QuickPickSheet> createState() => _QuickPickSheetState();
+}
+
+class _QuickPickSheetState extends State<QuickPickSheet> {
+  int? _selectedPlayers;
+  int? _selectedMaxTime;
+  double? _selectedWeight;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _restoreFromModel();
+  }
+
+  void _restoreFromModel() {
+    final model = AppModel.of(context, listen: false);
+
+    final playerSetting =
+        model.settings.setting(Settings.filterNumberOfPlayers.name);
+    if (playerSetting.enabled &&
+        _playerOptions.containsValue(playerSetting.value)) {
+      _selectedPlayers = playerSetting.value as int;
+    }
+
+    final maxTimeSetting =
+        model.settings.setting(Settings.filterMaximumTimeToPlay.name);
+    if (maxTimeSetting.enabled &&
+        _timeOptions.containsValue(maxTimeSetting.value)) {
+      _selectedMaxTime = maxTimeSetting.value as int;
+    }
+
+    final complexitySetting =
+        model.settings.setting(Settings.filterComplexity.name);
+    if (complexitySetting.enabled &&
+        _weightOptions.containsValue(complexitySetting.value)) {
+      _selectedWeight = complexitySetting.value as double;
+    }
+  }
+
+  static const Map<String, int> _playerOptions = {
+    '2': 2,
+    '3-4': 4,
+    '5+': 5,
+  };
+
+  static const Map<String, int> _timeOptions = {
+    '< 30 min': 30,
+    '30-60 min': 60,
+    '~60 min': 90,
+    '90+ min': 120,
+  };
+
+  static const Map<String, double> _weightOptions = {
+    'Light': 2.0,
+    'Medium': 3.0,
+    'Heavy': 5.0,
+  };
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: EdgeInsets.only(
+        left: 24,
+        right: 24,
+        top: 24,
+        bottom: MediaQuery.of(context).viewInsets.bottom + 24,
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Center(
+            child: Container(
+              width: 40,
+              height: 4,
+              decoration: BoxDecoration(
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
+                borderRadius: BorderRadius.circular(2),
+              ),
+            ),
+          ),
+          const SizedBox(height: 20),
+          Text(
+            'Quick Pick',
+            style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                  fontWeight: FontWeight.bold,
+                ),
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 4),
+          Text(
+            'Pick what matters, skip what doesn\'t',
+            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                ),
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 28),
+          _buildChipRow(
+            icon: Icons.people,
+            label: 'Players',
+            options: _playerOptions,
+            selected: _selectedPlayers,
+            onChanged: (value) => setState(() => _selectedPlayers = value),
+          ),
+          const SizedBox(height: 16),
+          _buildChipRow(
+            icon: Icons.schedule,
+            label: 'Time',
+            options: _timeOptions,
+            selected: _selectedMaxTime,
+            onChanged: (value) => setState(() => _selectedMaxTime = value),
+          ),
+          const SizedBox(height: 16),
+          _buildChipRow(
+            icon: Icons.fitness_center,
+            label: 'Weight',
+            options: _weightOptions,
+            selected: _selectedWeight,
+            onChanged: (value) => setState(() => _selectedWeight = value),
+          ),
+          const SizedBox(height: 28),
+          Consumer<AppModel>(
+            builder: (context, model, child) {
+              final hasSource = model.items.itemList.isNotEmpty;
+              return FilledButton.icon(
+                onPressed: hasSource ? () => _applyAndGo(context) : null,
+                icon: const Icon(Icons.casino, size: 24),
+                label: Text(
+                  hasSource ? 'Go!' : 'Add a source first',
+                  style: const TextStyle(
+                      fontSize: 16, fontWeight: FontWeight.bold),
+                ),
+                style: FilledButton.styleFrom(
+                  padding: const EdgeInsets.symmetric(vertical: 16),
+                ),
+              );
+            },
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildChipRow<T>({
+    required IconData icon,
+    required String label,
+    required Map<String, T> options,
+    required T? selected,
+    required ValueChanged<T?> onChanged,
+  }) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            Icon(icon, size: 20, color: Theme.of(context).colorScheme.primary),
+            const SizedBox(width: 8),
+            Text(
+              label,
+              style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                    fontWeight: FontWeight.bold,
+                  ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 8),
+        Wrap(
+          spacing: 8,
+          children: options.entries.map((entry) {
+            return AppChoiceChip(
+              label: entry.key,
+              selected: selected == entry.value,
+              onSelected: (isSelected) {
+                onChanged(isSelected ? entry.value : null);
+              },
+            );
+          }).toList(),
+        ),
+      ],
+    );
+  }
+
+  void _applyAndGo(BuildContext context) {
+    final model = AppModel.of(context, listen: false);
+
+    if (_selectedPlayers != null) {
+      final playerSetting =
+          model.settings.setting(Settings.filterNumberOfPlayers.name);
+      playerSetting.value = _selectedPlayers;
+      playerSetting.enabled = true;
+      model.settings.updateSetting(playerSetting);
+    }
+
+    if (_selectedMaxTime != null) {
+      final minTimeSetting =
+          model.settings.setting(Settings.filterMinimumTimeToPlay.name);
+      final maxTimeSetting =
+          model.settings.setting(Settings.filterMaximumTimeToPlay.name);
+      minTimeSetting.value = (_selectedMaxTime! * 0.5).floor();
+      maxTimeSetting.value = _selectedMaxTime;
+      minTimeSetting.enabled = true;
+      maxTimeSetting.enabled = true;
+      model.settings.updateSetting(minTimeSetting);
+      model.settings.updateSetting(maxTimeSetting);
+    }
+
+    if (_selectedWeight != null) {
+      final complexitySetting =
+          model.settings.setting(Settings.filterComplexity.name);
+      complexitySetting.value = _selectedWeight;
+      complexitySetting.enabled = true;
+      model.settings.updateSetting(complexitySetting);
+    }
+
+    model.invalidateCache();
+    model.updateStore();
+
+    Navigator.of(context).pop();
+
+    final randomPageSettings = r.Router.generateRouteSettings(
+      r.Router.randomRoute,
+      model,
+    );
+    model.pageRefreshed = true;
+    Navigator.of(context).pushReplacementNamed(
+      randomPageSettings.name!,
+      arguments: randomPageSettings.arguments,
+    );
+  }
+}

--- a/lib/guided_flow/step2_whos_playing.dart
+++ b/lib/guided_flow/step2_whos_playing.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:how_many_mobile_meeple/model/model.dart';
 import 'package:how_many_mobile_meeple/model/settings.dart';
+import 'package:how_many_mobile_meeple/components/app_choice_chip.dart';
 import 'package:how_many_mobile_meeple/components/step_header_card.dart';
 import 'package:how_many_mobile_meeple/components/info_message_box.dart';
 import 'package:how_many_mobile_meeple/tour_tips/tour_tip_keys.dart';
@@ -135,10 +136,9 @@ class _Step2WhosPlayingState extends State<Step2WhosPlaying> {
                   runSpacing: 8,
                   children: _presets.entries.map((preset) {
                     final isSelected = currentPlayers == preset.value;
-                    return FilterChip(
-                      label: Text('${preset.key} (${preset.value})'),
+                    return AppFilterChip(
+                      label: '${preset.key} (${preset.value})',
                       selected: isSelected,
-                      showCheckmark: false,
                       avatar: isSelected
                           ? Icon(
                               Icons.check_circle,
@@ -157,16 +157,6 @@ class _Step2WhosPlayingState extends State<Step2WhosPlaying> {
                           });
                         }
                       },
-                      selectedColor: Theme.of(context).colorScheme.secondary,
-                      backgroundColor:
-                          Theme.of(context).colorScheme.surfaceContainerHighest,
-                      labelStyle: TextStyle(
-                        color: isSelected
-                            ? Theme.of(context).colorScheme.onSecondary
-                            : Theme.of(context).colorScheme.onSurface,
-                        fontWeight:
-                            isSelected ? FontWeight.bold : FontWeight.normal,
-                      ),
                     );
                   }).toList(),
                 ),

--- a/lib/guided_flow/step3_time_available.dart
+++ b/lib/guided_flow/step3_time_available.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 import 'package:how_many_mobile_meeple/model/model.dart';
 import 'package:how_many_mobile_meeple/model/settings.dart';
 import 'package:how_many_mobile_meeple/app_common.dart';
+import 'package:how_many_mobile_meeple/components/app_choice_chip.dart';
 import 'package:how_many_mobile_meeple/components/step_header_card.dart';
 import 'package:how_many_mobile_meeple/components/info_message_box.dart';
 import 'package:how_many_mobile_meeple/tour_tips/tour_tip_keys.dart';
@@ -161,10 +162,9 @@ class _Step3TimeAvailableState extends State<Step3TimeAvailable> {
                     final isSelected =
                         maxTime == targetTime && minTime <= targetTime / 2;
 
-                    return ChoiceChip(
-                      label: Text(preset.key),
+                    return AppChoiceChip(
+                      label: preset.key,
                       selected: isSelected,
-                      showCheckmark: false,
                       avatar: Icon(
                         _getTimeIcon(targetTime),
                         size: 18,
@@ -175,7 +175,6 @@ class _Step3TimeAvailableState extends State<Step3TimeAvailable> {
                       onSelected: (selected) {
                         if (selected) {
                           setState(() {
-                            // Set time range around the preset
                             minTimeSetting.value = (targetTime * 0.5).floor();
                             maxTimeSetting.value = targetTime;
                             minTimeSetting.enabled = true;
@@ -187,16 +186,6 @@ class _Step3TimeAvailableState extends State<Step3TimeAvailable> {
                           });
                         }
                       },
-                      selectedColor: Theme.of(context).colorScheme.secondary,
-                      backgroundColor:
-                          Theme.of(context).colorScheme.surfaceContainerHighest,
-                      labelStyle: TextStyle(
-                        color: isSelected
-                            ? Theme.of(context).colorScheme.onSecondary
-                            : Theme.of(context).colorScheme.onSurface,
-                        fontWeight:
-                            isSelected ? FontWeight.bold : FontWeight.normal,
-                      ),
                     );
                   }).toList(),
                 ),

--- a/lib/guided_flow/step4_game_style.dart
+++ b/lib/guided_flow/step4_game_style.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:how_many_mobile_meeple/model/model.dart';
 import 'package:how_many_mobile_meeple/model/settings.dart';
+import 'package:how_many_mobile_meeple/components/app_choice_chip.dart';
 import 'package:how_many_mobile_meeple/components/step_header_card.dart';
 import 'package:how_many_mobile_meeple/components/info_message_box.dart';
 import 'package:how_many_mobile_meeple/tour_tips/tour_tip_keys.dart';
@@ -226,10 +227,9 @@ class _Step4GameStyleState extends State<Step4GameStyle> {
                         children: category.value.map((mechanic) {
                           final isSelected =
                               selectedMechanics.contains(mechanic);
-                          return FilterChip(
-                            label: Text(mechanic),
+                          return AppMechanicChip(
+                            label: mechanic,
                             selected: isSelected,
-                            showCheckmark: true,
                             onSelected: (selected) {
                               setState(() {
                                 if (selected) {
@@ -244,22 +244,6 @@ class _Step4GameStyleState extends State<Step4GameStyle> {
                                 model.invalidateCache();
                               });
                             },
-                            selectedColor:
-                                Theme.of(context).colorScheme.secondary,
-                            checkmarkColor:
-                                Theme.of(context).colorScheme.onSecondary,
-                            backgroundColor: Colors.grey[200],
-                            side: BorderSide(
-                              color: isSelected
-                                  ? Theme.of(context).colorScheme.secondary
-                                  : Colors.grey[400]!,
-                              width: 1.5,
-                            ),
-                            labelStyle: TextStyle(
-                              fontSize: 12,
-                              fontWeight: FontWeight.bold,
-                              color: isSelected ? Colors.white : Colors.black87,
-                            ),
                           );
                         }).toList(),
                       ),

--- a/lib/guided_flow/step5_final_actions.dart
+++ b/lib/guided_flow/step5_final_actions.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:how_many_mobile_meeple/components/quick_pick_sheet.dart';
 import 'package:how_many_mobile_meeple/model/model.dart';
 import 'package:how_many_mobile_meeple/platform/router.dart' as r;
 import 'package:how_many_mobile_meeple/save_dialog.dart';
@@ -64,8 +65,24 @@ class Step5FinalActions extends StatelessWidget {
 
                 const SizedBox(height: 32),
 
-                // Primary action - Random Game
+                // Primary action - Quick Pick
                 FilledButton.icon(
+                  onPressed: () => QuickPickSheet.show(context),
+                  icon: const Icon(Icons.bolt, size: 24),
+                  label: const Text(
+                    'Quick Pick',
+                    style: TextStyle(fontSize: 16),
+                  ),
+                  style: FilledButton.styleFrom(
+                    padding: const EdgeInsets.symmetric(
+                        vertical: 20, horizontal: 24),
+                  ),
+                ),
+
+                const SizedBox(height: 12),
+
+                // Secondary action - Random Game
+                OutlinedButton.icon(
                   onPressed: () {
                     final randomPageSettings = r.Router.generateRouteSettings(
                       r.Router.randomRoute,
@@ -79,7 +96,7 @@ class Step5FinalActions extends StatelessWidget {
                     key: TourTipKeys.randomButton,
                     style: const TextStyle(fontSize: 16),
                   ),
-                  style: FilledButton.styleFrom(
+                  style: OutlinedButton.styleFrom(
                     padding: const EdgeInsets.symmetric(
                         vertical: 20, horizontal: 24),
                   ),

--- a/lib/guided_flow_homepage.dart
+++ b/lib/guided_flow_homepage.dart
@@ -4,6 +4,7 @@ import 'package:how_many_mobile_meeple/model/model.dart';
 import 'package:how_many_mobile_meeple/how_many_meeple_app_bar.dart';
 import 'package:how_many_mobile_meeple/app_common.dart';
 import 'package:how_many_mobile_meeple/app_page.dart';
+import 'package:how_many_mobile_meeple/components/quick_pick_sheet.dart';
 import 'package:how_many_mobile_meeple/guided_flow/step1_select_source.dart';
 import 'package:how_many_mobile_meeple/guided_flow/step2_whos_playing.dart';
 import 'package:how_many_mobile_meeple/guided_flow/step3_time_available.dart';
@@ -325,6 +326,19 @@ class _GuidedFlowHomePageState extends State<GuidedFlowHomePage> {
                   label: const Text('Next'),
                 ),
 
+                // Quick Pick button
+                if (_currentStep < _totalSteps - 1) ...[
+                  const SizedBox(width: 8),
+                  FilledButton.tonalIcon(
+                    key: TourTipKeys.appBarQuickPick,
+                    onPressed: canProceedFromStep1
+                        ? () => QuickPickSheet.show(context)
+                        : null,
+                    icon: const Icon(Icons.bolt),
+                    label: const Text('Quick Pick'),
+                  ),
+                ],
+
                 // Finish button - skip straight to results
                 if (_currentStep < _totalSteps - 1) ...[
                   const SizedBox(width: 8),
@@ -376,14 +390,17 @@ class _GuidedFlowHomePageState extends State<GuidedFlowHomePage> {
             children: [
               DisclaimerText("(v:$version)", context),
               const SizedBox(width: 4),
-              GestureDetector(
-                onTap: () => Navigator.of(context).push(
-                  MaterialPageRoute(builder: (_) => const AboutPage()),
-                ),
-                child: Icon(
-                  Icons.info_outline,
-                  size: 20,
-                  color: Theme.of(context).colorScheme.primary,
+              Tooltip(
+                message: 'About',
+                child: GestureDetector(
+                  onTap: () => Navigator.of(context).push(
+                    MaterialPageRoute(builder: (_) => const AboutPage()),
+                  ),
+                  child: Icon(
+                    Icons.info_outline,
+                    size: 20,
+                    color: Theme.of(context).colorScheme.primary,
+                  ),
                 ),
               ),
             ],

--- a/lib/how_many_meeple_app_bar.dart
+++ b/lib/how_many_meeple_app_bar.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import 'app_common.dart';
+import 'components/quick_pick_sheet.dart';
 import 'model/model.dart';
 import 'platform/router.dart' as r;
 import 'save_dialog.dart';
@@ -20,6 +21,7 @@ class HowManyMeepleAppBar extends AppBar {
               ? null
               : IconButton(
                   icon: const Icon(Icons.arrow_back),
+                  tooltip: 'Back',
                   onPressed: () {
                     if (Navigator.of(context).canPop()) {
                       Navigator.of(context).pop();
@@ -49,9 +51,17 @@ class HowManyMeepleAppBar extends AppBar {
                 mode: LaunchMode.externalApplication,
               ),
             ),
+            Builder(
+              builder: (ctx) => IconButton(
+                icon: const Icon(Icons.bolt),
+                tooltip: 'Quick Pick',
+                onPressed: () => QuickPickSheet.show(ctx),
+              ),
+            ),
             if (hasSaveDialog && model != null)
               IconButton(
                 icon: const Icon(Icons.save),
+                tooltip: 'Save Settings',
                 onPressed: () => showDialog(
                   context: context,
                   builder: (context) => SaveDialog(model: model),

--- a/lib/model/model.dart
+++ b/lib/model/model.dart
@@ -165,7 +165,6 @@ class AppModel extends ChangeNotifier {
       return;
     }
     final store = await _getStore();
-    await store.clearIfVersionChanged();
     _items = await store.loadItems(AppCommon.maxItemsFromBgg);
     replaceSettings(await store.loadSettings(settings));
     hasLoadedPersistedData = true;

--- a/lib/storage/stored_preferences.dart
+++ b/lib/storage/stored_preferences.dart
@@ -4,12 +4,9 @@ import 'package:how_many_mobile_meeple/model/setting.dart';
 import 'package:how_many_mobile_meeple/model/settings.dart';
 import 'package:how_many_mobile_meeple/model/items.dart';
 import 'package:how_many_mobile_meeple/model/item.dart';
-import 'package:package_info_plus/package_info_plus.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 class StoredPreferences {
-  static const String _storageVersionKey = 'storage_version';
-
   static Future<SharedPreferences> getPrefs() async {
     return await SharedPreferences.getInstance();
   }
@@ -18,16 +15,6 @@ class StoredPreferences {
 
   StoredPreferences(SharedPreferences sharedPreferences) {
     _prefs = sharedPreferences;
-  }
-
-  Future<void> clearIfVersionChanged() async {
-    final packageInfo = await PackageInfo.fromPlatform();
-    final currentMajor = packageInfo.version.split('.').first;
-    final storedMajor = _prefs.getString(_storageVersionKey)?.split('.').first;
-    if (storedMajor != currentMajor) {
-      await _prefs.clear();
-      await _prefs.setString(_storageVersionKey, packageInfo.version);
-    }
   }
 
   Future<bool> saveSettings(Settings settings) async {

--- a/lib/tour_tips/tour_tip_definitions.dart
+++ b/lib/tour_tips/tour_tip_definitions.dart
@@ -24,6 +24,14 @@ class TourTipDefinitions {
       pageId: pageAppBar,
       order: 1,
     ),
+    TourTip(
+      id: 'appbar_quick_pick',
+      title: 'Quick Pick',
+      description:
+          'Skip the steps and pick a random game fast. Choose players, time, or weight and go.',
+      pageId: pageAppBar,
+      order: 2,
+    ),
 
     // Step 2 tips
     TourTip(

--- a/lib/tour_tips/tour_tip_keys.dart
+++ b/lib/tour_tips/tour_tip_keys.dart
@@ -7,6 +7,8 @@ class TourTipKeys {
       GlobalKey(debugLabel: 'appbar_news');
   static final GlobalKey appBarSettingsButton =
       GlobalKey(debugLabel: 'appbar_settings');
+  static final GlobalKey appBarQuickPick =
+      GlobalKey(debugLabel: 'appbar_quick_pick');
 
   // Step 2
   static final GlobalKey playerSlider =
@@ -36,6 +38,7 @@ class TourTipKeys {
         return {
           'appbar_news': appBarNewsButton,
           'appbar_settings': appBarSettingsButton,
+          'appbar_quick_pick': appBarQuickPick,
         };
       case TourTipDefinitions.pageStep2:
         return {

--- a/test/components/app_choice_chip_test.dart
+++ b/test/components/app_choice_chip_test.dart
@@ -1,0 +1,135 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:how_many_mobile_meeple/components/app_choice_chip.dart';
+
+Widget _wrapWidget(Widget child) => MaterialApp(
+      home: Scaffold(body: child),
+    );
+
+void main() {
+  group('AppChoiceChip', () {
+    testWidgets('renders label text', (tester) async {
+      await tester.pumpWidget(_wrapWidget(
+        AppChoiceChip(
+          label: 'Test',
+          selected: false,
+          onSelected: (_) {},
+        ),
+      ));
+
+      expect(find.text('Test'), findsOneWidget);
+    });
+
+    testWidgets('calls onSelected when tapped', (tester) async {
+      bool? selectedValue;
+      await tester.pumpWidget(_wrapWidget(
+        AppChoiceChip(
+          label: 'Test',
+          selected: false,
+          onSelected: (value) => selectedValue = value,
+        ),
+      ));
+
+      await tester.tap(find.text('Test'));
+      expect(selectedValue, isTrue);
+    });
+
+    testWidgets('does not show checkmark', (tester) async {
+      await tester.pumpWidget(_wrapWidget(
+        AppChoiceChip(
+          label: 'Test',
+          selected: true,
+          onSelected: (_) {},
+        ),
+      ));
+
+      final chip = tester.widget<ChoiceChip>(find.byType(ChoiceChip));
+      expect(chip.showCheckmark, isFalse);
+    });
+
+    testWidgets('renders avatar when provided', (tester) async {
+      await tester.pumpWidget(_wrapWidget(
+        AppChoiceChip(
+          label: 'Test',
+          selected: false,
+          onSelected: (_) {},
+          avatar: const Icon(Icons.people),
+        ),
+      ));
+
+      expect(find.byIcon(Icons.people), findsOneWidget);
+    });
+  });
+
+  group('AppFilterChip', () {
+    testWidgets('renders label text', (tester) async {
+      await tester.pumpWidget(_wrapWidget(
+        AppFilterChip(
+          label: 'Filter',
+          selected: false,
+          onSelected: (_) {},
+        ),
+      ));
+
+      expect(find.text('Filter'), findsOneWidget);
+    });
+
+    testWidgets('calls onSelected when tapped', (tester) async {
+      bool? selectedValue;
+      await tester.pumpWidget(_wrapWidget(
+        AppFilterChip(
+          label: 'Filter',
+          selected: false,
+          onSelected: (value) => selectedValue = value,
+        ),
+      ));
+
+      await tester.tap(find.text('Filter'));
+      expect(selectedValue, isTrue);
+    });
+  });
+
+  group('AppMechanicChip', () {
+    testWidgets('renders label text', (tester) async {
+      await tester.pumpWidget(_wrapWidget(
+        AppMechanicChip(
+          label: 'Deck Building',
+          selected: false,
+          onSelected: (_) {},
+        ),
+      ));
+
+      expect(find.text('Deck Building'), findsOneWidget);
+    });
+
+    testWidgets('respects enabled state', (tester) async {
+      bool? called;
+      await tester.pumpWidget(_wrapWidget(
+        AppMechanicChip(
+          label: 'Deck Building',
+          selected: false,
+          enabled: false,
+          onSelected: (value) => called = value,
+        ),
+      ));
+
+      await tester.tap(find.text('Deck Building'));
+      expect(called, isNull);
+    });
+
+    testWidgets('calls onSelected when enabled and tapped', (tester) async {
+      bool? selectedValue;
+      await tester.pumpWidget(_wrapWidget(
+        AppMechanicChip(
+          label: 'Deck Building',
+          selected: false,
+          enabled: true,
+          onSelected: (value) => selectedValue = value,
+        ),
+      ));
+
+      await tester.tap(find.text('Deck Building'));
+      expect(selectedValue, isTrue);
+    });
+  });
+}

--- a/test/components/quick_pick_sheet_test.dart
+++ b/test/components/quick_pick_sheet_test.dart
@@ -1,0 +1,273 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:how_many_mobile_meeple/components/quick_pick_sheet.dart';
+import 'package:how_many_mobile_meeple/model/item.dart';
+import 'package:how_many_mobile_meeple/model/model.dart';
+import 'package:how_many_mobile_meeple/model/settings.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+Widget _buildTestApp({AppModel? model}) {
+  final appModel = model ?? AppModel();
+  return ChangeNotifierProvider<AppModel>.value(
+    value: appModel,
+    child: MaterialApp(
+      onGenerateRoute: (settings) => MaterialPageRoute(
+        builder: (_) => Scaffold(
+          body: Builder(
+            builder: (context) => ElevatedButton(
+              onPressed: () => QuickPickSheet.show(context),
+              child: const Text('Open'),
+            ),
+          ),
+        ),
+        settings: settings,
+      ),
+      home: Scaffold(
+        body: Builder(
+          builder: (context) => ElevatedButton(
+            onPressed: () => QuickPickSheet.show(context),
+            child: const Text('Open'),
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  group('QuickPickSheet', () {
+    testWidgets('displays all three chip rows', (tester) async {
+      await tester.pumpWidget(_buildTestApp());
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Players'), findsOneWidget);
+      expect(find.text('Time'), findsOneWidget);
+      expect(find.text('Weight'), findsOneWidget);
+    });
+
+    testWidgets('displays player options', (tester) async {
+      await tester.pumpWidget(_buildTestApp());
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('2'), findsOneWidget);
+      expect(find.text('3-4'), findsOneWidget);
+      expect(find.text('5+'), findsOneWidget);
+    });
+
+    testWidgets('displays time options', (tester) async {
+      await tester.pumpWidget(_buildTestApp());
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('< 30 min'), findsOneWidget);
+      expect(find.text('30-60 min'), findsOneWidget);
+      expect(find.text('~60 min'), findsOneWidget);
+      expect(find.text('90+ min'), findsOneWidget);
+    });
+
+    testWidgets('displays weight options', (tester) async {
+      await tester.pumpWidget(_buildTestApp());
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Light'), findsOneWidget);
+      expect(find.text('Medium'), findsOneWidget);
+      expect(find.text('Heavy'), findsOneWidget);
+    });
+
+    testWidgets('displays Go button when source exists', (tester) async {
+      final model = AppModel();
+      await model.addItem(Item('testuser'));
+      await tester.pumpWidget(_buildTestApp(model: model));
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Go!'), findsOneWidget);
+    });
+
+    testWidgets('tapping a chip selects it', (tester) async {
+      await tester.pumpWidget(_buildTestApp());
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('3-4'));
+      await tester.pumpAndSettle();
+
+      final chip = tester.widget<ChoiceChip>(
+        find.ancestor(
+          of: find.text('3-4'),
+          matching: find.byType(ChoiceChip),
+        ),
+      );
+      expect(chip.selected, isTrue);
+    });
+
+    testWidgets('tapping a selected chip deselects it', (tester) async {
+      await tester.pumpWidget(_buildTestApp());
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('3-4'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('3-4'));
+      await tester.pumpAndSettle();
+
+      final chip = tester.widget<ChoiceChip>(
+        find.ancestor(
+          of: find.text('3-4'),
+          matching: find.byType(ChoiceChip),
+        ),
+      );
+      expect(chip.selected, isFalse);
+    });
+
+    testWidgets('Go button is disabled when no source is added',
+        (tester) async {
+      final model = AppModel();
+      await tester.pumpWidget(_buildTestApp(model: model));
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Add a source first'), findsOneWidget);
+      final button = tester.widget<FilledButton>(find.byType(FilledButton));
+      expect(button.onPressed, isNull);
+    });
+
+    testWidgets('Go button applies player filter to model', (tester) async {
+      final model = AppModel();
+      await model.addItem(Item('testuser'));
+      await tester.pumpWidget(_buildTestApp(model: model));
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('5+'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Go!'));
+      await tester.pumpAndSettle();
+
+      final playerSetting =
+          model.settings.setting(Settings.filterNumberOfPlayers.name);
+      expect(playerSetting.value, 5);
+      expect(playerSetting.enabled, isTrue);
+    });
+
+    testWidgets('Go button applies time filter to model', (tester) async {
+      final model = AppModel();
+      await model.addItem(Item('testuser'));
+      await tester.pumpWidget(_buildTestApp(model: model));
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('30-60 min'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Go!'));
+      await tester.pumpAndSettle();
+
+      final maxTimeSetting =
+          model.settings.setting(Settings.filterMaximumTimeToPlay.name);
+      final minTimeSetting =
+          model.settings.setting(Settings.filterMinimumTimeToPlay.name);
+      expect(maxTimeSetting.value, 60);
+      expect(minTimeSetting.value, 30);
+      expect(maxTimeSetting.enabled, isTrue);
+      expect(minTimeSetting.enabled, isTrue);
+    });
+
+    testWidgets('Go button applies weight filter to model', (tester) async {
+      final model = AppModel();
+      await model.addItem(Item('testuser'));
+      await tester.pumpWidget(_buildTestApp(model: model));
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Heavy'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Go!'));
+      await tester.pumpAndSettle();
+
+      final complexitySetting =
+          model.settings.setting(Settings.filterComplexity.name);
+      expect(complexitySetting.value, 5.0);
+      expect(complexitySetting.enabled, isTrue);
+    });
+
+    testWidgets('restores last selections from model settings', (tester) async {
+      final model = AppModel();
+      await model.addItem(Item('testuser'));
+
+      final playerSetting =
+          model.settings.setting(Settings.filterNumberOfPlayers.name);
+      playerSetting.value = 4;
+      playerSetting.enabled = true;
+      model.settings.updateSetting(playerSetting);
+
+      final maxTimeSetting =
+          model.settings.setting(Settings.filterMaximumTimeToPlay.name);
+      maxTimeSetting.value = 90;
+      maxTimeSetting.enabled = true;
+      model.settings.updateSetting(maxTimeSetting);
+
+      final complexitySetting =
+          model.settings.setting(Settings.filterComplexity.name);
+      complexitySetting.value = 2.0;
+      complexitySetting.enabled = true;
+      model.settings.updateSetting(complexitySetting);
+
+      await tester.pumpWidget(_buildTestApp(model: model));
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      final playerChip = tester.widget<ChoiceChip>(
+        find.ancestor(of: find.text('3-4'), matching: find.byType(ChoiceChip)),
+      );
+      expect(playerChip.selected, isTrue);
+
+      final timeChip = tester.widget<ChoiceChip>(
+        find.ancestor(
+            of: find.text('~60 min'), matching: find.byType(ChoiceChip)),
+      );
+      expect(timeChip.selected, isTrue);
+
+      final weightChip = tester.widget<ChoiceChip>(
+        find.ancestor(
+            of: find.text('Light'), matching: find.byType(ChoiceChip)),
+      );
+      expect(weightChip.selected, isTrue);
+    });
+
+    testWidgets('Go button without selections does not alter filters',
+        (tester) async {
+      final model = AppModel();
+      await model.addItem(Item('testuser'));
+      final defaultPlayers =
+          model.settings.setting(Settings.filterNumberOfPlayers.name).value;
+      final defaultMaxTime =
+          model.settings.setting(Settings.filterMaximumTimeToPlay.name).value;
+      final defaultComplexity =
+          model.settings.setting(Settings.filterComplexity.name).value;
+
+      await tester.pumpWidget(_buildTestApp(model: model));
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Go!'));
+      await tester.pumpAndSettle();
+
+      expect(model.settings.setting(Settings.filterNumberOfPlayers.name).value,
+          defaultPlayers);
+      expect(
+          model.settings.setting(Settings.filterMaximumTimeToPlay.name).value,
+          defaultMaxTime);
+      expect(model.settings.setting(Settings.filterComplexity.name).value,
+          defaultComplexity);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Adds Quick Pick bottom sheet (players, time, weight chips) that applies filters and jumps straight to a random game
- Entry points: app bar bolt icon, floating button group, step navigation, and Step 5
- Go button disabled until a game source (collection/geeklist/trending) is added
- Reopening Quick Pick highlights the last-used selections
- Shared chip widgets (AppChoiceChip, AppFilterChip, AppMechanicChip) extracted from 5 files
- Floating button group deduplicated with _floatingIconButton helper
- Tooltips added to all icon-only buttons
- Tour tip introduces Quick Pick on first homepage visit
- Removed major-version data wipe so saved data persists across upgrades
- Fixed dead contributor links (SWH30 -> oldstevekenobi, DragonC -> BGG profile)

Closes #74

## Test plan

- [x] 140 tests pass (flutter test)
- [x] flutter analyze clean
- [x] Open Quick Pick from app bar, floating buttons, step nav, and Step 5
- [x] Verify Go button is disabled with no source, enabled with a source
- [x] Select chips, tap Go, confirm correct game filters applied
- [x] Reopen Quick Pick after a pick and confirm last selections are highlighted
- [x] Verify tour tip fires once on first homepage load, not again after dismissal
- [x] Confirm saved collections/settings persist after app update (no data wipe)
- [x] Verify contributor links resolve (oldstevekenobi GitHub, DragonC BGG)