### PR TITLE
feat: add favourites and ignored games with swipe gestures

### DIFF
--- a/lib/app_page.dart
+++ b/lib/app_page.dart
@@ -1,6 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
-import 'package:share_plus/share_plus.dart';
 import 'package:how_many_mobile_meeple/platform/router.dart' as r;
 import 'package:provider/provider.dart';
 import 'package:how_many_mobile_meeple/components/drawer_bgg_filter.dart';
@@ -10,7 +8,6 @@ import 'package:how_many_mobile_meeple/components/quick_pick_sheet.dart';
 import 'package:how_many_mobile_meeple/favourites/ignored_games_service.dart';
 import 'app_common.dart';
 import 'components/component_factory.dart';
-import 'model/game.dart';
 import 'model/model.dart';
 import 'model/settings.dart';
 import 'pwa/pwa_install_service.dart';
@@ -317,66 +314,6 @@ mixin AppPage {
           ),
         ],
       );
-
-  ElevatedButton shareButton(BuildContext context, Game game) {
-    return ElevatedButton(
-      child: Tooltip(
-        message: 'Share',
-        child: Icon(
-          Icons.share,
-          color: Theme.of(context).selectedRowColor,
-        ),
-      ),
-      onPressed: () async {
-        final baseUri = Uri.base.removeFragment();
-        final uri = baseUri.replace(
-            fragment: '/game/${game.name.replaceAll(' ', '+')}/${game.id}');
-        final url = uri.toString();
-        try {
-          await SharePlus.instance.share(
-            ShareParams(
-              title: AppCommon.randomGameMessage(game.name),
-              uri: uri,
-            ),
-          );
-        } catch (_) {
-          _showCopyLinkDialog(context, url);
-        }
-      },
-      style: ButtonStyle(
-          backgroundColor: WidgetStateProperty.all<Color>(
-              Theme.of(context).colorScheme.secondary),
-          shape: WidgetStateProperty.all<OutlinedBorder>(RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(30.0)))),
-    );
-  }
-
-  void _showCopyLinkDialog(BuildContext context, String url) {
-    showDialog(
-      context: context,
-      builder: (dialogContext) => AlertDialog(
-        title: const Text('Share Link'),
-        content: SelectableText(url),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(dialogContext).pop(),
-            child: const Text('Close'),
-          ),
-          FilledButton.icon(
-            onPressed: () {
-              Clipboard.setData(ClipboardData(text: url));
-              Navigator.of(dialogContext).pop();
-              ScaffoldMessenger.of(context).showSnackBar(
-                const SnackBar(content: Text('Link copied to clipboard')),
-              );
-            },
-            icon: const Icon(Icons.copy),
-            label: const Text('Copy Link'),
-          ),
-        ],
-      ),
-    );
-  }
 
   Widget pageDrawer(BuildContext context) {
     var staticDataComponentLength = 6;

--- a/lib/app_page.dart
+++ b/lib/app_page.dart
@@ -7,6 +7,7 @@ import 'package:how_many_mobile_meeple/components/drawer_bgg_filter.dart';
 import 'package:how_many_mobile_meeple/components/drawer_switch.dart';
 import 'package:how_many_mobile_meeple/components/app_default_padding.dart';
 import 'package:how_many_mobile_meeple/components/quick_pick_sheet.dart';
+import 'package:how_many_mobile_meeple/favourites/ignored_games_service.dart';
 import 'app_common.dart';
 import 'components/component_factory.dart';
 import 'model/game.dart';
@@ -70,6 +71,7 @@ mixin AppPage {
             index: 2),
         _buildAdvancedModeToggle(model, context, index: 3),
         _buildTourTipsToggle(context, index: 4),
+        _buildIgnoredGamesLink(context, index: 5),
       ];
 
   Widget _buildAdvancedModeToggle(AppModel model, BuildContext context,
@@ -132,6 +134,32 @@ mixin AppPage {
                 value: isEnabled,
               ),
             ],
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildIgnoredGamesLink(BuildContext context, {int index = 0}) {
+    return FutureBuilder<IgnoredGamesService>(
+      future: IgnoredGamesService.instance(),
+      builder: (context, snapshot) {
+        final count = snapshot.hasData ? snapshot.data!.games.length : 0;
+        return Material(
+          color:
+              index % 2 == 0 ? Theme.of(context).highlightColor : Colors.white,
+          child: ListTile(
+            dense: true,
+            leading: Icon(Icons.visibility_off,
+                size: 20, color: Theme.of(context).colorScheme.secondary),
+            title: Text(
+              'Ignored Games${count > 0 ? ' ($count)' : ''}',
+              style: const TextStyle(fontSize: 13),
+            ),
+            onTap: () {
+              Navigator.of(context).pop();
+              Navigator.of(context).pushNamed(r.Router.ignoredRoute);
+            },
           ),
         );
       },

--- a/lib/components/game_image_with_stats.dart
+++ b/lib/components/game_image_with_stats.dart
@@ -56,9 +56,7 @@ class GameImageWithStats extends StatelessWidget with ScreenTools {
                   ),
                 ),
               ),
-            if (_hasImage &&
-                MediaQuery.of(context).size.width >= 1024 &&
-                game.thumbnail != null)
+            if (_hasImage && isWideScreen(context) && game.thumbnail != null)
               Positioned(
                 left: 24,
                 top: 0,

--- a/lib/favourites/favourite_game.dart
+++ b/lib/favourites/favourite_game.dart
@@ -1,0 +1,25 @@
+class FavouriteGame {
+  final int id;
+  final String name;
+  final String? thumbnail;
+
+  FavouriteGame({
+    required this.id,
+    required this.name,
+    this.thumbnail,
+  });
+
+  factory FavouriteGame.fromJson(Map<String, dynamic> json) {
+    return FavouriteGame(
+      id: json['id'],
+      name: json['name'],
+      thumbnail: json['thumbnail'],
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'name': name,
+        'thumbnail': thumbnail,
+      };
+}

--- a/lib/favourites/favourites_service.dart
+++ b/lib/favourites/favourites_service.dart
@@ -1,0 +1,21 @@
+import 'game_list_service.dart';
+import 'ignored_games_service.dart';
+
+class FavouritesService extends GameListService {
+  static FavouritesService? _instance;
+
+  FavouritesService._() : super('favourite_games');
+
+  static Future<FavouritesService> instance() async {
+    if (_instance != null) return _instance!;
+    _instance = FavouritesService._();
+    await _instance!.load();
+    final ignored = IgnoredGamesService.cached;
+    if (ignored != null) _instance!.linkOpposite(ignored);
+    return _instance!;
+  }
+
+  static FavouritesService? get cached => _instance;
+
+  static void resetForTesting() => _instance = null;
+}

--- a/lib/favourites/game_action_buttons.dart
+++ b/lib/favourites/game_action_buttons.dart
@@ -1,0 +1,158 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:share_plus/share_plus.dart';
+import 'favourite_game.dart';
+import 'favourites_service.dart';
+import 'ignored_games_service.dart';
+import '../model/game.dart';
+
+class GameActionButtons extends StatefulWidget {
+  final Game game;
+
+  const GameActionButtons({super.key, required this.game});
+
+  @override
+  State<GameActionButtons> createState() => _GameActionButtonsState();
+}
+
+class _GameActionButtonsState extends State<GameActionButtons> {
+  FavouritesService? _favService;
+  IgnoredGamesService? _ignoreService;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadServices();
+  }
+
+  Future<void> _loadServices() async {
+    final fav = await FavouritesService.instance();
+    final ignore = await IgnoredGamesService.instance();
+    fav.addListener(_rebuild);
+    ignore.addListener(_rebuild);
+    if (mounted) {
+      setState(() {
+        _favService = fav;
+        _ignoreService = ignore;
+      });
+    }
+  }
+
+  void _rebuild() {
+    if (mounted) setState(() {});
+  }
+
+  @override
+  void dispose() {
+    _favService?.removeListener(_rebuild);
+    _ignoreService?.removeListener(_rebuild);
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_favService == null || _ignoreService == null) {
+      return const SizedBox.shrink();
+    }
+
+    final game = widget.game;
+    final favGame =
+        FavouriteGame(id: game.id, name: game.name, thumbnail: game.thumbnail);
+    final isFav = _favService!.contains(game.id);
+    final isIgnored = _ignoreService!.contains(game.id);
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          ElevatedButton.icon(
+            onPressed: () => _favService!.toggle(favGame),
+            icon: Icon(isFav ? Icons.favorite : Icons.favorite_border),
+            label: Text(isFav ? 'Unfavourite' : 'Favourite'),
+            style: ElevatedButton.styleFrom(
+              backgroundColor: isFav
+                  ? Colors.amber.shade700
+                  : Theme.of(context).colorScheme.secondary,
+              foregroundColor: Colors.white,
+              shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(30)),
+            ),
+          ),
+          const SizedBox(width: 12),
+          ElevatedButton.icon(
+            onPressed: () {
+              _ignoreService!.toggle(favGame);
+              if (!isIgnored && Navigator.of(context).canPop()) {
+                Navigator.of(context).pop();
+              }
+            },
+            icon: Icon(isIgnored ? Icons.visibility : Icons.visibility_off),
+            label: Text(isIgnored ? 'Unignore' : 'Ignore'),
+            style: ElevatedButton.styleFrom(
+              backgroundColor: isIgnored
+                  ? Theme.of(context).colorScheme.secondary
+                  : Theme.of(context).colorScheme.error,
+              foregroundColor: Colors.white,
+              shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(30)),
+            ),
+          ),
+          const SizedBox(width: 12),
+          ElevatedButton.icon(
+            onPressed: () => _share(context, game),
+            icon: const Icon(Icons.share),
+            label: const Text('Share'),
+            style: ElevatedButton.styleFrom(
+              backgroundColor: Theme.of(context).colorScheme.secondary,
+              foregroundColor: Colors.white,
+              shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(30)),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _share(BuildContext context, Game game) async {
+    final baseUri = Uri.base.removeFragment();
+    final uri = baseUri.replace(
+        fragment: '/game/${game.name.replaceAll(' ', '+')}/${game.id}');
+    final url = uri.toString();
+    try {
+      await SharePlus.instance.share(
+        ShareParams(title: '${game.name} on How Many Meeple', uri: uri),
+      );
+    } catch (_) {
+      _showCopyLinkDialog(context, url);
+    }
+  }
+
+  void _showCopyLinkDialog(BuildContext context, String url) {
+    showDialog(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: const Text('Share Link'),
+        content: SelectableText(url),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(),
+            child: const Text('Close'),
+          ),
+          FilledButton.icon(
+            onPressed: () {
+              Clipboard.setData(ClipboardData(text: url));
+              Navigator.of(dialogContext).pop();
+              ScaffoldMessenger.of(context).showSnackBar(
+                const SnackBar(content: Text('Link copied to clipboard')),
+              );
+            },
+            icon: const Icon(Icons.copy),
+            label: const Text('Copy Link'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/favourites/game_list_page.dart
+++ b/lib/favourites/game_list_page.dart
@@ -1,0 +1,153 @@
+import 'package:flutter/material.dart';
+import 'package:how_many_mobile_meeple/app_page.dart';
+import 'package:how_many_mobile_meeple/components/platform_independent_image.dart';
+import 'package:how_many_mobile_meeple/how_many_meeple_app_bar.dart';
+import 'package:how_many_mobile_meeple/platform/router.dart' as r;
+import 'favourite_game.dart';
+import 'game_list_service.dart';
+
+class GameListPage extends StatefulWidget {
+  final String title;
+  final IconData emptyIcon;
+  final String emptyTitle;
+  final String emptyDescription;
+  final Future<GameListService> Function() serviceFactory;
+
+  const GameListPage({
+    super.key,
+    required this.title,
+    required this.emptyIcon,
+    required this.emptyTitle,
+    required this.emptyDescription,
+    required this.serviceFactory,
+  });
+
+  @override
+  State<GameListPage> createState() => _GameListPageState();
+}
+
+class _GameListPageState extends State<GameListPage> with AppPage {
+  GameListService? _service;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadService();
+  }
+
+  Future<void> _loadService() async {
+    final service = await widget.serviceFactory();
+    service.addListener(_onChanged);
+    setState(() => _service = service);
+  }
+
+  void _onChanged() {
+    if (mounted) setState(() {});
+  }
+
+  @override
+  void dispose() {
+    _service?.removeListener(_onChanged);
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: HowManyMeepleAppBar(widget.title, context: context),
+      endDrawer: pageDrawer(context),
+      body: _service == null
+          ? const Center(child: CircularProgressIndicator())
+          : _buildBody(context),
+    );
+  }
+
+  Widget _buildBody(BuildContext context) {
+    final games = _service!.games;
+    if (games.isEmpty) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.all(32),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(widget.emptyIcon,
+                  size: 64, color: Theme.of(context).colorScheme.secondary),
+              const SizedBox(height: 16),
+              Text(
+                widget.emptyTitle,
+                style: Theme.of(context).textTheme.titleMedium,
+              ),
+              const SizedBox(height: 8),
+              Text(
+                widget.emptyDescription,
+                textAlign: TextAlign.center,
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                      color: Theme.of(context).colorScheme.onSurfaceVariant,
+                    ),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    return ListView.builder(
+      itemCount: games.length,
+      itemBuilder: (context, index) {
+        final game = games[index];
+        return Dismissible(
+          key: ValueKey(game.id),
+          direction: DismissDirection.endToStart,
+          background: Container(
+            alignment: Alignment.centerRight,
+            padding: const EdgeInsets.only(right: 20),
+            color: Theme.of(context).colorScheme.error,
+            child: const Icon(Icons.delete, color: Colors.white),
+          ),
+          onDismissed: (_) => _service!.remove(game.id),
+          child: _buildGameTile(context, game, index),
+        );
+      },
+    );
+  }
+
+  Widget _buildGameTile(BuildContext context, FavouriteGame game, int index) {
+    final isEven = index % 2 == 0;
+    return Material(
+      color: isEven
+          ? Colors.transparent
+          : Theme.of(context).colorScheme.primary.withAlpha(8),
+      child: ListTile(
+        leading: ClipRRect(
+          borderRadius: BorderRadius.circular(4),
+          child: SizedBox(
+            width: 44,
+            height: 44,
+            child: game.thumbnail != null
+                ? PlatformIndependentImage(
+                    imageUrl: game.thumbnail!,
+                    fit: BoxFit.cover,
+                  )
+                : Container(
+                    color: Theme.of(context).colorScheme.primaryContainer,
+                    child: Icon(Icons.casino,
+                        size: 22,
+                        color:
+                            Theme.of(context).colorScheme.onPrimaryContainer),
+                  ),
+          ),
+        ),
+        title: Text(game.name),
+        trailing: IconButton(
+          icon: Icon(Icons.remove_circle_outline,
+              color: Theme.of(context).colorScheme.error),
+          tooltip: 'Remove',
+          onPressed: () => _service!.remove(game.id),
+        ),
+        onTap: () => Navigator.of(context).pushNamed(
+            '${r.Router.gameDetailRoute}/${game.name.replaceAll(' ', '+')}/${game.id}'),
+      ),
+    );
+  }
+}

--- a/lib/favourites/game_list_service.dart
+++ b/lib/favourites/game_list_service.dart
@@ -1,0 +1,54 @@
+import 'dart:convert';
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'favourite_game.dart';
+
+abstract class GameListService extends ChangeNotifier {
+  final String storageKey;
+  GameListService? _opposite;
+
+  List<FavouriteGame> _games = [];
+
+  List<FavouriteGame> get games => List.unmodifiable(_games);
+
+  GameListService(this.storageKey);
+
+  void linkOpposite(GameListService other) {
+    _opposite = other;
+    other._opposite = this;
+  }
+
+  bool contains(int gameId) => _games.any((g) => g.id == gameId);
+
+  void toggle(FavouriteGame game) {
+    final index = _games.indexWhere((g) => g.id == game.id);
+    if (index >= 0) {
+      _games.removeAt(index);
+    } else {
+      _games.insert(0, game);
+      _opposite?.remove(game.id);
+    }
+    _save();
+    notifyListeners();
+  }
+
+  void remove(int gameId) {
+    _games.removeWhere((g) => g.id == gameId);
+    _save();
+    notifyListeners();
+  }
+
+  Future<void> load() async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString(storageKey);
+    if (raw == null) return;
+    final list = jsonDecode(raw) as List;
+    _games = list.map((e) => FavouriteGame.fromJson(e)).toList();
+  }
+
+  Future<void> _save() async {
+    final prefs = await SharedPreferences.getInstance();
+    final encoded = jsonEncode(_games.map((g) => g.toJson()).toList());
+    await prefs.setString(storageKey, encoded);
+  }
+}

--- a/lib/favourites/ignored_games_service.dart
+++ b/lib/favourites/ignored_games_service.dart
@@ -1,0 +1,21 @@
+import 'favourites_service.dart';
+import 'game_list_service.dart';
+
+class IgnoredGamesService extends GameListService {
+  static IgnoredGamesService? _instance;
+
+  IgnoredGamesService._() : super('ignored_games');
+
+  static Future<IgnoredGamesService> instance() async {
+    if (_instance != null) return _instance!;
+    _instance = IgnoredGamesService._();
+    await _instance!.load();
+    final favs = FavouritesService.cached;
+    if (favs != null) _instance!.linkOpposite(favs);
+    return _instance!;
+  }
+
+  static IgnoredGamesService? get cached => _instance;
+
+  static void resetForTesting() => _instance = null;
+}

--- a/lib/guided_flow/step1_select_source.dart
+++ b/lib/guided_flow/step1_select_source.dart
@@ -1,10 +1,6 @@
-import 'dart:async';
-import 'dart:math' as math;
-
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:tutorial_coach_mark/tutorial_coach_mark.dart';
 import 'package:how_many_mobile_meeple/model/model.dart';
 import 'package:how_many_mobile_meeple/model/item.dart';
 import 'package:how_many_mobile_meeple/app_common.dart';
@@ -137,7 +133,14 @@ class _Step1SelectSourceState extends State<Step1SelectSource> {
 
         if (step.key.currentContext == null) continue;
 
-        await _showSingleTip(step, service, storage, tipIds);
+        final shown = await service.showSingleTip(
+          context: context,
+          key: step.key,
+          id: step.id,
+          title: step.title,
+          description: step.description,
+        );
+        if (!shown) _dismissed = true;
       }
 
       if (mounted) _switchToTab(0);
@@ -148,132 +151,7 @@ class _Step1SelectSourceState extends State<Step1SelectSource> {
     });
   }
 
-  static const double _maxFocusRadius = 150.0;
-
-  double _cappedPaddingForKey(GlobalKey key) {
-    final renderBox = key.currentContext?.findRenderObject() as RenderBox?;
-    if (renderBox == null) return 10;
-    final screenWidth = MediaQuery.of(key.currentContext!).size.width;
-    final targetSize = renderBox.size;
-    final maxDimension = math.max(targetSize.width, targetSize.height);
-    final maxRadius = math.min(_maxFocusRadius, screenWidth * 0.2);
-    final padding = maxRadius - maxDimension * 0.6;
-    return math.max(padding, 4);
-  }
-
   bool _dismissed = false;
-
-  Future<void> _showSingleTip(
-    _Step1TipStep step,
-    TourTipService service,
-    TourTipStorage storage,
-    List<String> tipIds,
-  ) async {
-    final completer = Completer<void>();
-
-    final padding = _cappedPaddingForKey(step.key);
-
-    final target = TargetFocus(
-      identify: step.id,
-      keyTarget: step.key,
-      alignSkip: Alignment.topRight,
-      enableOverlayTab: true,
-      enableTargetTab: true,
-      paddingFocus: padding,
-      contents: [
-        TargetContent(
-          align: ContentAlign.bottom,
-          builder: (context, controller) {
-            final screenWidth = MediaQuery.of(context).size.width;
-            return Container(
-              constraints: BoxConstraints(maxWidth: screenWidth * 0.7),
-              padding: const EdgeInsets.all(16),
-              decoration: BoxDecoration(
-                color: Colors.black87,
-                borderRadius: BorderRadius.circular(12),
-              ),
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    step.title,
-                    style: const TextStyle(
-                      color: Colors.white,
-                      fontWeight: FontWeight.bold,
-                      fontSize: 20,
-                    ),
-                  ),
-                  const SizedBox(height: 8),
-                  Text(
-                    step.description,
-                    style: const TextStyle(
-                      color: Colors.white,
-                      fontSize: 15,
-                    ),
-                  ),
-                  const SizedBox(height: 16),
-                  Wrap(
-                    alignment: WrapAlignment.spaceBetween,
-                    spacing: 8,
-                    runSpacing: 4,
-                    children: [
-                      const Text(
-                        'Tap anywhere to continue',
-                        style: TextStyle(
-                          color: Colors.white70,
-                          fontSize: 12,
-                          fontStyle: FontStyle.italic,
-                        ),
-                      ),
-                      GestureDetector(
-                        onTap: () async {
-                          _dismissed = true;
-                          await service.dismissAll();
-                          for (final tid in tipIds) {
-                            await storage.markSeen(tid);
-                          }
-                          _activeCoachMark?.skip();
-                        },
-                        child: const Text(
-                          'Dismiss Tour',
-                          style: TextStyle(
-                            color: Colors.white70,
-                            fontSize: 12,
-                            decoration: TextDecoration.underline,
-                            decorationColor: Colors.white70,
-                          ),
-                        ),
-                      ),
-                    ],
-                  ),
-                ],
-              ),
-            );
-          },
-        ),
-      ],
-    );
-
-    _activeCoachMark = TutorialCoachMark(
-      targets: [target],
-      colorShadow: Colors.black,
-      opacityShadow: 0.8,
-      paddingFocus: 10,
-      hideSkip: true,
-      onFinish: () => completer.complete(),
-      onSkip: () {
-        _dismissed = true;
-        completer.complete();
-        return true;
-      },
-    )..show(context: context);
-
-    await completer.future;
-    _activeCoachMark = null;
-  }
-
-  TutorialCoachMark? _activeCoachMark;
 
   void _switchToTab(int index) {
     if (mounted) {
@@ -302,7 +180,7 @@ class _Step1SelectSourceState extends State<Step1SelectSource> {
       builder: (context, model, child) => Card(
         elevation: 2,
         child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 20),
+          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 16),
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
@@ -364,24 +242,28 @@ class _Step1SelectSourceState extends State<Step1SelectSource> {
         visualDensity: VisualDensity.compact,
         tapTargetSize: MaterialTapTargetSize.shrinkWrap,
         padding: WidgetStatePropertyAll(
-          const EdgeInsets.symmetric(horizontal: 8),
+          const EdgeInsets.symmetric(horizontal: 2),
         ),
       ),
       segments: [
         ButtonSegment(
           value: 0,
-          label: Text('Trending', key: _tabSelectorKey),
-          icon: const Icon(Icons.local_fire_department, size: 18),
+          label: Text('Trending',
+              key: _tabSelectorKey,
+              overflow: TextOverflow.ellipsis,
+              maxLines: 1),
+          icon: const Icon(Icons.local_fire_department, size: 16),
         ),
         const ButtonSegment(
           value: 1,
-          label: Text('My Collection'),
-          icon: Icon(Icons.person, size: 18),
+          label:
+              Text('Collection', overflow: TextOverflow.ellipsis, maxLines: 1),
+          icon: Icon(Icons.person, size: 16),
         ),
         const ButtonSegment(
           value: 2,
-          label: Text('Geeklist'),
-          icon: Icon(Icons.list, size: 18),
+          label: Text('Geeklist', overflow: TextOverflow.ellipsis, maxLines: 1),
+          icon: Icon(Icons.list, size: 16),
         ),
       ],
       selected: {_tabIndex},

--- a/lib/guided_flow/step2_whos_playing.dart
+++ b/lib/guided_flow/step2_whos_playing.dart
@@ -37,7 +37,7 @@ class _Step2WhosPlayingState extends State<Step2WhosPlaying> {
         return Card(
           elevation: 2,
           child: Padding(
-            padding: const EdgeInsets.all(20.0),
+            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 16),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [

--- a/lib/guided_flow/step3_time_available.dart
+++ b/lib/guided_flow/step3_time_available.dart
@@ -49,7 +49,7 @@ class _Step3TimeAvailableState extends State<Step3TimeAvailable> {
         return Card(
           elevation: 2,
           child: Padding(
-            padding: const EdgeInsets.all(20.0),
+            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 16),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [

--- a/lib/guided_flow/step4_game_style.dart
+++ b/lib/guided_flow/step4_game_style.dart
@@ -73,7 +73,7 @@ class _Step4GameStyleState extends State<Step4GameStyle> {
         return Card(
           elevation: 2,
           child: Padding(
-            padding: const EdgeInsets.all(20.0),
+            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 16),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [

--- a/lib/guided_flow/step5_final_actions.dart
+++ b/lib/guided_flow/step5_final_actions.dart
@@ -23,7 +23,7 @@ class Step5FinalActions extends StatelessWidget {
         return Card(
           elevation: 2,
           child: Padding(
-            padding: const EdgeInsets.all(20.0),
+            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 16),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [

--- a/lib/guided_flow_homepage.dart
+++ b/lib/guided_flow_homepage.dart
@@ -128,7 +128,7 @@ class _GuidedFlowHomePageState extends State<GuidedFlowHomePage> {
       },
       child: SingleChildScrollView(
         child: Padding(
-          padding: const EdgeInsets.all(16.0),
+          padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 16),
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
@@ -330,9 +330,6 @@ class _GuidedFlowHomePageState extends State<GuidedFlowHomePage> {
                 if (_currentStep < _totalSteps - 1) ...[
                   const SizedBox(width: 8),
                   FilledButton.tonalIcon(
-                    key: (ModalRoute.of(context)?.isCurrent ?? true)
-                        ? TourTipKeys.appBarQuickPick
-                        : null,
                     onPressed: canProceedFromStep1
                         ? () => QuickPickSheet.show(context)
                         : null,

--- a/lib/guided_flow_homepage.dart
+++ b/lib/guided_flow_homepage.dart
@@ -330,7 +330,9 @@ class _GuidedFlowHomePageState extends State<GuidedFlowHomePage> {
                 if (_currentStep < _totalSteps - 1) ...[
                   const SizedBox(width: 8),
                   FilledButton.tonalIcon(
-                    key: TourTipKeys.appBarQuickPick,
+                    key: (ModalRoute.of(context)?.isCurrent ?? true)
+                        ? TourTipKeys.appBarQuickPick
+                        : null,
                     onPressed: canProceedFromStep1
                         ? () => QuickPickSheet.show(context)
                         : null,

--- a/lib/how_many_meeple_app_bar.dart
+++ b/lib/how_many_meeple_app_bar.dart
@@ -7,6 +7,7 @@ import 'model/model.dart';
 import 'platform/router.dart' as r;
 import 'save_dialog.dart';
 import 'tour_tips/tour_tip_keys.dart';
+import 'favourites/favourites_service.dart';
 
 class HowManyMeepleAppBar extends AppBar {
   HowManyMeepleAppBar(String subtitle,
@@ -43,7 +44,9 @@ class HowManyMeepleAppBar extends AppBar {
           ),
           actions: [
             IconButton(
-              key: isHomePage ? TourTipKeys.appBarNewsButton : null,
+              key: isHomePage && (ModalRoute.of(context)?.isCurrent ?? true)
+                  ? TourTipKeys.appBarNewsButton
+                  : null,
               icon: const Icon(Icons.newspaper),
               tooltip: 'Board Game News',
               onPressed: () => launchUrl(
@@ -58,6 +61,20 @@ class HowManyMeepleAppBar extends AppBar {
                 onPressed: () => QuickPickSheet.show(ctx),
               ),
             ),
+            Builder(
+              builder: (ctx) => FutureBuilder<FavouritesService>(
+                future: FavouritesService.instance(),
+                builder: (context, snapshot) => IconButton(
+                  key: isHomePage && (ModalRoute.of(ctx)?.isCurrent ?? true)
+                      ? TourTipKeys.appBarFavourites
+                      : null,
+                  icon: const Icon(Icons.favorite),
+                  tooltip: 'Favourites',
+                  onPressed: () =>
+                      Navigator.of(ctx).pushNamed(r.Router.favouritesRoute),
+                ),
+              ),
+            ),
             if (hasSaveDialog && model != null)
               IconButton(
                 icon: const Icon(Icons.save),
@@ -69,7 +86,9 @@ class HowManyMeepleAppBar extends AppBar {
               ),
             Builder(
               builder: (ctx) => IconButton(
-                key: isHomePage ? TourTipKeys.appBarSettingsButton : null,
+                key: isHomePage && (ModalRoute.of(ctx)?.isCurrent ?? true)
+                    ? TourTipKeys.appBarSettingsButton
+                    : null,
                 icon: const Icon(Icons.settings),
                 tooltip: 'Settings',
                 onPressed: () => Scaffold.of(ctx).openEndDrawer(),

--- a/lib/how_many_meeple_app_bar.dart
+++ b/lib/how_many_meeple_app_bar.dart
@@ -7,7 +7,6 @@ import 'model/model.dart';
 import 'platform/router.dart' as r;
 import 'save_dialog.dart';
 import 'tour_tips/tour_tip_keys.dart';
-import 'favourites/favourites_service.dart';
 
 class HowManyMeepleAppBar extends AppBar {
   HowManyMeepleAppBar(String subtitle,
@@ -43,56 +42,52 @@ class HowManyMeepleAppBar extends AppBar {
             ],
           ),
           actions: [
-            IconButton(
+            Row(
               key: isHomePage && (ModalRoute.of(context)?.isCurrent ?? true)
-                  ? TourTipKeys.appBarNewsButton
+                  ? TourTipKeys.appBarActions
                   : null,
-              icon: const Icon(Icons.newspaper),
-              tooltip: 'Board Game News',
-              onPressed: () => launchUrl(
-                Uri.parse('https://www.boardgamenews.co.uk/'),
-                mode: LaunchMode.externalApplication,
-              ),
-            ),
-            Builder(
-              builder: (ctx) => IconButton(
-                icon: const Icon(Icons.bolt),
-                tooltip: 'Quick Pick',
-                onPressed: () => QuickPickSheet.show(ctx),
-              ),
-            ),
-            Builder(
-              builder: (ctx) => FutureBuilder<FavouritesService>(
-                future: FavouritesService.instance(),
-                builder: (context, snapshot) => IconButton(
-                  key: isHomePage && (ModalRoute.of(ctx)?.isCurrent ?? true)
-                      ? TourTipKeys.appBarFavourites
-                      : null,
-                  icon: const Icon(Icons.favorite),
-                  tooltip: 'Favourites',
-                  onPressed: () =>
-                      Navigator.of(ctx).pushNamed(r.Router.favouritesRoute),
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                IconButton(
+                  icon: const Icon(Icons.newspaper),
+                  tooltip: 'Board Game News',
+                  onPressed: () => launchUrl(
+                    Uri.parse('https://www.boardgamenews.co.uk/'),
+                    mode: LaunchMode.externalApplication,
+                  ),
                 ),
-              ),
-            ),
-            if (hasSaveDialog && model != null)
-              IconButton(
-                icon: const Icon(Icons.save),
-                tooltip: 'Save Settings',
-                onPressed: () => showDialog(
-                  context: context,
-                  builder: (context) => SaveDialog(model: model),
+                Builder(
+                  builder: (ctx) => IconButton(
+                    icon: const Icon(Icons.bolt),
+                    tooltip: 'Quick Pick',
+                    onPressed: () => QuickPickSheet.show(ctx),
+                  ),
                 ),
-              ),
-            Builder(
-              builder: (ctx) => IconButton(
-                key: isHomePage && (ModalRoute.of(ctx)?.isCurrent ?? true)
-                    ? TourTipKeys.appBarSettingsButton
-                    : null,
-                icon: const Icon(Icons.settings),
-                tooltip: 'Settings',
-                onPressed: () => Scaffold.of(ctx).openEndDrawer(),
-              ),
+                Builder(
+                  builder: (ctx) => IconButton(
+                    icon: const Icon(Icons.favorite),
+                    tooltip: 'Favourites',
+                    onPressed: () =>
+                        Navigator.of(ctx).pushNamed(r.Router.favouritesRoute),
+                  ),
+                ),
+                if (hasSaveDialog && model != null)
+                  IconButton(
+                    icon: const Icon(Icons.save),
+                    tooltip: 'Save Settings',
+                    onPressed: () => showDialog(
+                      context: context,
+                      builder: (context) => SaveDialog(model: model),
+                    ),
+                  ),
+                Builder(
+                  builder: (ctx) => IconButton(
+                    icon: const Icon(Icons.settings),
+                    tooltip: 'Settings',
+                    onPressed: () => Scaffold.of(ctx).openEndDrawer(),
+                  ),
+                ),
+              ],
             ),
           ],
         );

--- a/lib/model/bgg_cache.dart
+++ b/lib/model/bgg_cache.dart
@@ -1,5 +1,8 @@
 import 'dart:math';
 
+import 'package:how_many_mobile_meeple/favourites/favourites_service.dart';
+import 'package:how_many_mobile_meeple/favourites/ignored_games_service.dart';
+
 import 'game.dart';
 import 'games.dart';
 
@@ -9,38 +12,86 @@ class BggCache {
   late int _cacheTimestamp;
 
   Games get games => _games;
-  late Games _remainingGames;
+  late List<Game> _remainingPool;
 
   int get durationInMinutes => _durationMinutes;
   Game? _stickyRandom;
+
+  static const int _favouriteWeight = 3;
 
   Game? get random {
     if (games.games.isEmpty) {
       return null;
     }
-    if (_remainingGames.games.isEmpty) {
-      return _stickyRandom;
+    _removeIgnoredFromPool();
+    if (_remainingPool.isEmpty) {
+      return _validatedSticky;
     }
     _stickyRandom = _nextRandom();
     return _stickyRandom;
   }
 
   Game _nextRandom() {
-    var randomGameId = Random().nextInt(_remainingGames.games.length);
-    var selectedGame = _remainingGames.games[randomGameId];
-    _cacheRemaining(selectedGame);
+    var randomIndex = Random().nextInt(_remainingPool.length);
+    var selectedGame = _remainingPool[randomIndex];
+    _remainingPool.removeWhere((g) => g.id == selectedGame.id);
     return selectedGame;
   }
 
-  void _cacheRemaining(Game game) {
-    _remainingGames = _games.remove(game);
+  void _removeIgnoredFromPool() {
+    final ignoredService = IgnoredGamesService.cached;
+    if (ignoredService == null) return;
+    _remainingPool.removeWhere((g) => ignoredService.contains(g.id));
   }
 
-  Game? get lastRandom => _stickyRandom ?? random;
+  Game? get _validatedSticky {
+    if (_stickyRandom == null) return null;
+    final ignoredService = IgnoredGamesService.cached;
+    if (ignoredService != null && ignoredService.contains(_stickyRandom!.id)) {
+      _stickyRandom = null;
+    }
+    return _stickyRandom;
+  }
+
+  Game? get lastRandom => _validatedSticky ?? random;
 
   BggCache(this._games, this._durationMinutes) {
     refreshCacheTimestamp();
-    _remainingGames = _games;
+    _remainingPool = _buildWeightedPool();
+  }
+
+  Game? randomIncludingIgnored() {
+    final pool = _buildWeightedPool(includeIgnored: true);
+    if (pool.isEmpty) return null;
+    final index = Random().nextInt(pool.length);
+    return pool[index];
+  }
+
+  List<Game> _buildWeightedPool({bool includeIgnored = false}) {
+    final ignoredService = IgnoredGamesService.cached;
+    final favouritesService = FavouritesService.cached;
+
+    var pool = _games.games;
+    if (!includeIgnored) {
+      pool = pool
+          .where((g) => !(ignoredService?.contains(g.id) ?? false))
+          .toList();
+    }
+
+    if (favouritesService != null) {
+      final extras = <Game>[];
+      for (final game in pool) {
+        if (favouritesService.contains(game.id)) {
+          for (var i = 1; i < _favouriteWeight; i++) {
+            extras.add(game);
+          }
+        }
+      }
+      pool = [...pool, ...extras];
+    }
+
+    pool.shuffle();
+    return pool;
   }
 
   int epochToSeconds(int millisEpoch) => (millisEpoch / 1000).floor();

--- a/lib/platform/common/game_detail_page.dart
+++ b/lib/platform/common/game_detail_page.dart
@@ -4,6 +4,7 @@ import 'package:how_many_mobile_meeple/api/game_detail_service.dart';
 import 'package:how_many_mobile_meeple/components/app_default_padding.dart';
 import 'package:how_many_mobile_meeple/components/game_image_with_stats.dart';
 import 'package:how_many_mobile_meeple/components/recommendations_widget.dart';
+import 'package:how_many_mobile_meeple/favourites/game_action_buttons.dart';
 import 'package:how_many_mobile_meeple/how_many_meeple_app_bar.dart';
 import 'package:how_many_mobile_meeple/model/game.dart';
 import 'package:how_many_mobile_meeple/model/model.dart';
@@ -69,7 +70,7 @@ class _GameDetailPageState extends State<GameDetailPage>
                 ),
               ),
               AppDefaultPadding(child: GameImageWithStats(game: game)),
-              shareButton(context, game),
+              GameActionButtons(game: game),
               RecommendationsWidget(sourceGame: game, model: model),
             ],
           ),

--- a/lib/platform/router.dart
+++ b/lib/platform/router.dart
@@ -1,4 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:how_many_mobile_meeple/about_page.dart';
+import 'package:how_many_mobile_meeple/favourites/favourites_service.dart';
+import 'package:how_many_mobile_meeple/favourites/game_list_page.dart';
+import 'package:how_many_mobile_meeple/favourites/ignored_games_service.dart';
 import 'package:how_many_mobile_meeple/model/model.dart';
 import 'package:how_many_mobile_meeple/platform/common/game_detail_page.dart';
 import 'package:how_many_mobile_meeple/platform/pages.dart';
@@ -11,6 +15,9 @@ class Router {
   static const String randomRoute = '/random';
   static const String settingsRoute = '/settings';
   static const String gameDetailRoute = '/game';
+  static const String favouritesRoute = '/favourites';
+  static const String ignoredRoute = '/ignored';
+  static const String aboutRoute = '/about';
 
   static List<String> routeList = [
     randomRoute,
@@ -52,6 +59,31 @@ class Router {
       case Router.settingsRoute:
         return MaterialPageRoute(
             builder: (_) => SettingsSummaryPage(), settings: settings);
+      case Router.favouritesRoute:
+        return MaterialPageRoute(
+            builder: (_) => GameListPage(
+                  title: 'Favourites',
+                  emptyIcon: Icons.favorite_border,
+                  emptyTitle: 'No favourites yet',
+                  emptyDescription:
+                      'Swipe right on a game in the list or tap the heart on a game page to add favourites.',
+                  serviceFactory: FavouritesService.instance,
+                ),
+            settings: settings);
+      case Router.ignoredRoute:
+        return MaterialPageRoute(
+            builder: (_) => GameListPage(
+                  title: 'Ignored Games',
+                  emptyIcon: Icons.visibility_off_outlined,
+                  emptyTitle: 'No ignored games',
+                  emptyDescription:
+                      'Swipe left on a game in the list to hide it from future results.',
+                  serviceFactory: IgnoredGamesService.instance,
+                ),
+            settings: settings);
+      case Router.aboutRoute:
+        return MaterialPageRoute(
+            builder: (_) => const AboutPage(), settings: settings);
       default:
         return MaterialPageRoute(
             builder: (_) => Pages.platformPages().homePage(),

--- a/lib/platform/web_or_tablet/enhanced_list_games_display.dart
+++ b/lib/platform/web_or_tablet/enhanced_list_games_display.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:how_many_mobile_meeple/components/app_default_padding.dart';
+import 'package:how_many_mobile_meeple/favourites/favourite_game.dart';
+import 'package:how_many_mobile_meeple/favourites/favourites_service.dart';
+import 'package:how_many_mobile_meeple/favourites/ignored_games_service.dart';
 import 'package:how_many_mobile_meeple/platform/router.dart' as r;
 import '../../app_page.dart';
 import '../../app_common.dart';
@@ -9,6 +12,7 @@ import 'package:how_many_mobile_meeple/model/model.dart';
 import '../../model/game.dart';
 import '../../model/games.dart';
 import '../../network_content_widget.dart';
+import '../../screen_tools.dart';
 import 'package:how_many_mobile_meeple/components/platform_independent_image.dart';
 import 'package:how_many_mobile_meeple/components/rating_badge.dart';
 
@@ -24,218 +28,338 @@ class EnhancedListGamesDisplayPage extends NetworkWidget with AppPage {
   }
 
   Widget displayGame(BuildContext context, AppModel model) {
-    var cachedGames = model.bggCache;
-    var heading = [
-      TableRow(children: [
-        const TableCell(
-          verticalAlignment: TableCellVerticalAlignment.middle,
-          child: SizedBox(width: 48),
-        ),
-        TableCell(
-          verticalAlignment: TableCellVerticalAlignment.middle,
-          child: AppDefaultPadding(
-            child: TextButton(
-                style: TextButton.styleFrom(padding: EdgeInsets.zero),
-                onPressed: () {
-                  model.toggleSortDirection();
-                  model.sortGameField = SortableGameField.name;
-                  model.refreshState();
-                },
-                child: Container(
-                    alignment: Alignment.bottomLeft,
-                    child: Row(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        HeadingText("Name", context),
-                        if (model.sortGameField == SortableGameField.name)
-                          Icon(
-                            model.sortDirection == SortOrder.Asc
-                                ? Icons.arrow_upward
-                                : Icons.arrow_downward,
-                            size: 12,
-                            color: Theme.of(context).colorScheme.secondary,
-                          ),
-                      ],
-                    ))),
+    return FutureBuilder(
+      future: Future.wait([
+        FavouritesService.instance(),
+        IgnoredGamesService.instance(),
+      ]),
+      builder: (context, snapshot) {
+        if (!snapshot.hasData) {
+          return const Center(child: CircularProgressIndicator());
+        }
+        final favService = snapshot.data![0] as FavouritesService;
+        final ignoreService = snapshot.data![1] as IgnoredGamesService;
+        return _GameListBody(
+          model: model,
+          favouritesService: favService,
+          ignoredService: ignoreService,
+        );
+      },
+    );
+  }
+}
+
+class _GameListBody extends StatefulWidget {
+  final AppModel model;
+  final FavouritesService favouritesService;
+  final IgnoredGamesService ignoredService;
+
+  const _GameListBody({
+    required this.model,
+    required this.favouritesService,
+    required this.ignoredService,
+  });
+
+  @override
+  State<_GameListBody> createState() => _GameListBodyState();
+}
+
+class _GameListBodyState extends State<_GameListBody> with ScreenTools {
+  bool _showIgnored = false;
+
+  @override
+  void initState() {
+    super.initState();
+    widget.favouritesService.addListener(_rebuild);
+    widget.ignoredService.addListener(_rebuild);
+  }
+
+  @override
+  void dispose() {
+    widget.favouritesService.removeListener(_rebuild);
+    widget.ignoredService.removeListener(_rebuild);
+    super.dispose();
+  }
+
+  void _rebuild() {
+    if (mounted) setState(() {});
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final model = widget.model;
+    var allGames = model.bggCache.games
+        .getGamesBy(field: model.sortGameField, order: model.sortDirection);
+    final games = _showIgnored
+        ? allGames
+        : allGames.where((g) => !widget.ignoredService.contains(g.id)).toList();
+
+    if (games.isEmpty) {
+      return _buildExhaustedState(context);
+    }
+
+    return Column(
+      children: [
+        _buildHeader(context, model),
+        Expanded(
+          child: ListView.builder(
+            itemCount: games.length,
+            itemBuilder: (context, index) =>
+                _buildDismissibleRow(context, games[index], index),
           ),
         ),
-        TableCell(
-          verticalAlignment: TableCellVerticalAlignment.middle,
-          child: AppDefaultPadding(
-            child: TextButton(
-                style: TextButton.styleFrom(padding: EdgeInsets.zero),
-                onPressed: () {
-                  model.toggleSortDirection();
-                  model.sortGameField = SortableGameField.maxPlaytime;
-                  model.refreshState();
-                },
-                child: Row(mainAxisAlignment: MainAxisAlignment.end, children: [
-                  Icon(Icons.timer,
-                      size: 18, color: Theme.of(context).colorScheme.secondary),
-                  if (model.sortGameField == SortableGameField.maxPlaytime)
-                    Icon(
-                      model.sortDirection == SortOrder.Asc
-                          ? Icons.arrow_upward
-                          : Icons.arrow_downward,
-                      size: 12,
-                      color: Theme.of(context).colorScheme.secondary,
-                    ),
-                ])),
-          ),
+      ],
+    );
+  }
+
+  Widget _buildExhaustedState(BuildContext context) {
+    final hasIgnored = widget.ignoredService.games.isNotEmpty;
+
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.format_list_numbered,
+                size: 64, color: Theme.of(context).colorScheme.secondary),
+            const SizedBox(height: 16),
+            Text(
+              'All games are currently hidden',
+              style: Theme.of(context).textTheme.titleMedium,
+              textAlign: TextAlign.center,
+            ),
+            if (hasIgnored) ...[
+              const SizedBox(height: 12),
+              Text(
+                'Want to try again including your ignored games?',
+                textAlign: TextAlign.center,
+                style: Theme.of(context).textTheme.bodyMedium,
+              ),
+              const SizedBox(height: 16),
+              FilledButton.icon(
+                onPressed: () => setState(() => _showIgnored = true),
+                icon: const Icon(Icons.refresh),
+                label: const Text('Include ignored games'),
+              ),
+            ],
+          ],
         ),
-        TableCell(
-          verticalAlignment: TableCellVerticalAlignment.middle,
-          child: AppDefaultPadding(
-            child: TextButton(
-                style: TextButton.styleFrom(padding: EdgeInsets.zero),
-                onPressed: () {
-                  model.toggleSortDirection();
-                  model.sortGameField = SortableGameField.weight;
-                  model.refreshState();
-                },
-                child: Row(mainAxisAlignment: MainAxisAlignment.end, children: [
-                  Icon(Icons.fitness_center,
-                      size: 18, color: Theme.of(context).colorScheme.secondary),
-                  if (model.sortGameField == SortableGameField.weight)
-                    Icon(
-                      model.sortDirection == SortOrder.Asc
-                          ? Icons.arrow_upward
-                          : Icons.arrow_downward,
-                      size: 12,
-                      color: Theme.of(context).colorScheme.secondary,
-                    ),
-                ])),
-          ),
-        ),
-        TableCell(
-          verticalAlignment: TableCellVerticalAlignment.middle,
-          child: AppDefaultPadding(
-            child: TextButton(
-                style: TextButton.styleFrom(padding: EdgeInsets.zero),
-                onPressed: () {
-                  model.toggleSortDirection();
-                  model.sortGameField = SortableGameField.rating;
-                  model.refreshState();
-                },
-                child: Row(mainAxisAlignment: MainAxisAlignment.end, children: [
-                  Icon(Icons.star,
-                      size: 18, color: Theme.of(context).colorScheme.secondary),
-                  if (model.sortGameField == SortableGameField.rating)
-                    Icon(
-                      model.sortDirection == SortOrder.Asc
-                          ? Icons.arrow_upward
-                          : Icons.arrow_downward,
-                      size: 12,
-                      color: Theme.of(context).colorScheme.secondary,
-                    ),
-                ])),
-          ),
-        ),
-      ])
-    ];
-    return SingleChildScrollView(
-      scrollDirection: Axis.vertical,
-      child: Table(
-        defaultColumnWidth: const FixedColumnWidth(60),
-        columnWidths: const {
-          0: FixedColumnWidth(56),
-          1: FlexColumnWidth(4.0),
-          2: MinColumnWidth(FlexColumnWidth(1.0), FixedColumnWidth(80)),
-          3: FlexColumnWidth(1.0),
-          4: FixedColumnWidth(60),
-        },
-        children: heading +
-            (cachedGames.games
-                .getGamesBy(
-                    field: model.sortGameField, order: model.sortDirection)
-                .asMap()
-                .entries
-                .map(
-                  (entry) => _buildRow(context, entry.value, entry.key),
-                )).toList(),
       ),
     );
   }
 
-  TableRow _buildRow(BuildContext context, Game game, int index) {
-    final isEven = index % 2 == 0;
-    return TableRow(
-        decoration: BoxDecoration(
-          color: isEven
-              ? Colors.transparent
-              : Theme.of(context).colorScheme.primary.withAlpha(8),
-          border:
-              Border(bottom: BorderSide(color: Theme.of(context).dividerColor)),
-        ),
+  Widget _buildHeader(BuildContext context, AppModel model) {
+    return Container(
+      decoration: BoxDecoration(
+        border:
+            Border(bottom: BorderSide(color: Theme.of(context).dividerColor)),
+      ),
+      child: Row(
         children: [
-          TableCell(
-            verticalAlignment: TableCellVerticalAlignment.middle,
-            child: Padding(
-              padding: const EdgeInsets.symmetric(vertical: 4, horizontal: 4),
-              child: ClipRRect(
-                borderRadius: BorderRadius.circular(4),
-                child: SizedBox(
-                  width: 44,
-                  height: 44,
-                  child: game.thumbnail != null
-                      ? PlatformIndependentImage(
-                          imageUrl: game.thumbnail!,
-                          fit: BoxFit.cover,
-                        )
-                      : Container(
-                          color: Theme.of(context).colorScheme.primaryContainer,
-                          child: Icon(Icons.casino,
-                              size: 22,
-                              color: Theme.of(context)
-                                  .colorScheme
-                                  .onPrimaryContainer),
+          const SizedBox(width: 56),
+          Expanded(
+            flex: 4,
+            child: _sortButton(context, model, 'Name', SortableGameField.name,
+                alignment: Alignment.centerLeft),
+          ),
+          SizedBox(
+            width: 80,
+            child: _sortButton(
+                context, model, null, SortableGameField.maxPlaytime,
+                icon: Icons.timer),
+          ),
+          SizedBox(
+            width: 60,
+            child: _sortButton(context, model, null, SortableGameField.weight,
+                icon: Icons.fitness_center),
+          ),
+          SizedBox(
+            width: 60,
+            child: _sortButton(context, model, null, SortableGameField.rating,
+                icon: Icons.star),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _sortButton(BuildContext context, AppModel model, String? label,
+      SortableGameField field,
+      {IconData? icon, Alignment alignment = Alignment.centerRight}) {
+    return TextButton(
+      style: TextButton.styleFrom(padding: EdgeInsets.zero),
+      onPressed: () {
+        model.toggleSortDirection();
+        model.sortGameField = field;
+        model.refreshState();
+      },
+      child: Container(
+        alignment: alignment,
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 12),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (label != null) HeadingText(label, context),
+            if (icon != null)
+              Icon(icon,
+                  size: 18, color: Theme.of(context).colorScheme.secondary),
+            if (model.sortGameField == field)
+              Icon(
+                model.sortDirection == SortOrder.Asc
+                    ? Icons.arrow_upward
+                    : Icons.arrow_downward,
+                size: 12,
+                color: Theme.of(context).colorScheme.secondary,
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildDismissibleRow(BuildContext context, Game game, int index) {
+    final isFav = widget.favouritesService.contains(game.id);
+    final favGame =
+        FavouriteGame(id: game.id, name: game.name, thumbnail: game.thumbnail);
+
+    return Dismissible(
+      key: ValueKey(game.id),
+      background: Container(
+        alignment: Alignment.centerLeft,
+        padding: const EdgeInsets.only(left: 20),
+        color: Colors.amber.shade700,
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(isFav ? Icons.heart_broken : Icons.favorite,
+                color: Colors.white),
+            const SizedBox(width: 8),
+            Text(isFav ? 'Unfavourite' : 'Favourite',
+                style: const TextStyle(
+                    color: Colors.white, fontWeight: FontWeight.bold)),
+          ],
+        ),
+      ),
+      secondaryBackground: Container(
+        alignment: Alignment.centerRight,
+        padding: const EdgeInsets.only(right: 20),
+        color: Theme.of(context).colorScheme.error,
+        child: const Row(
+          mainAxisSize: MainAxisSize.min,
+          mainAxisAlignment: MainAxisAlignment.end,
+          children: [
+            Text('Ignore',
+                style: TextStyle(
+                    color: Colors.white, fontWeight: FontWeight.bold)),
+            SizedBox(width: 8),
+            Icon(Icons.visibility_off, color: Colors.white),
+          ],
+        ),
+      ),
+      confirmDismiss: (direction) async {
+        if (direction == DismissDirection.startToEnd) {
+          widget.favouritesService.toggle(favGame);
+          return false;
+        } else {
+          widget.ignoredService.toggle(favGame);
+          return true;
+        }
+      },
+      child: _buildRow(context, game, index, isFav),
+    );
+  }
+
+  Widget _buildRow(BuildContext context, Game game, int index, bool isFav) {
+    final isEven = index % 2 == 0;
+    final isWide = isWideScreen(context);
+    final favGame =
+        FavouriteGame(id: game.id, name: game.name, thumbnail: game.thumbnail);
+
+    return Container(
+      decoration: BoxDecoration(
+        color: isEven
+            ? Colors.transparent
+            : Theme.of(context).colorScheme.primary.withAlpha(8),
+        border:
+            Border(bottom: BorderSide(color: Theme.of(context).dividerColor)),
+      ),
+      child: Row(
+        children: [
+          Padding(
+            padding: const EdgeInsets.symmetric(vertical: 4, horizontal: 4),
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(4),
+              child: SizedBox(
+                width: 44,
+                height: 44,
+                child: game.thumbnail != null
+                    ? PlatformIndependentImage(
+                        imageUrl: game.thumbnail!,
+                        fit: BoxFit.cover,
+                      )
+                    : Container(
+                        color: Theme.of(context).colorScheme.primaryContainer,
+                        child: Icon(Icons.casino,
+                            size: 22,
+                            color: Theme.of(context)
+                                .colorScheme
+                                .onPrimaryContainer),
+                      ),
+              ),
+            ),
+          ),
+          Expanded(
+            flex: 4,
+            child: AppDefaultPadding(
+              child: InkWell(
+                onTap: () => Navigator.of(context).pushNamed(
+                    '${r.Router.gameDetailRoute}/${game.name.replaceAll(' ', '+')}/${game.id}'),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Row(
+                      children: [
+                        if (isFav)
+                          Padding(
+                            padding: const EdgeInsets.only(right: 4),
+                            child: Icon(Icons.favorite,
+                                size: 14, color: Colors.amber.shade700),
+                          ),
+                        Flexible(
+                          child: Text(game.name,
+                              style: const TextStyle(
+                                decoration: TextDecoration.underline,
+                              )),
                         ),
+                      ],
+                    ),
+                    const SizedBox(height: 2),
+                    Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Icon(Icons.people,
+                            size: 12,
+                            color: Theme.of(context).colorScheme.secondary),
+                        const SizedBox(width: 3),
+                        Text(
+                          game.minPlayers == game.maxPlayers
+                              ? '${game.minPlayers} players'
+                              : '${game.minPlayers}-${game.maxPlayers} players',
+                          style: TextStyle(
+                              fontSize: 11,
+                              color: Theme.of(context).colorScheme.secondary),
+                        ),
+                      ],
+                    ),
+                  ],
                 ),
               ),
             ),
           ),
-          TableCell(
-              verticalAlignment: TableCellVerticalAlignment.middle,
-              child: AppDefaultPadding(
-                child: Container(
-                  alignment: Alignment.centerLeft,
-                  child: InkWell(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        Text(game.name,
-                            style: const TextStyle(
-                              decoration: TextDecoration.underline,
-                            )),
-                        const SizedBox(height: 2),
-                        Row(
-                          mainAxisSize: MainAxisSize.min,
-                          children: [
-                            Icon(Icons.people,
-                                size: 12,
-                                color: Theme.of(context).colorScheme.secondary),
-                            const SizedBox(width: 3),
-                            Text(
-                              game.minPlayers == game.maxPlayers
-                                  ? '${game.minPlayers} players'
-                                  : '${game.minPlayers}-${game.maxPlayers} players',
-                              style: TextStyle(
-                                  fontSize: 11,
-                                  color:
-                                      Theme.of(context).colorScheme.secondary),
-                            ),
-                          ],
-                        ),
-                      ],
-                    ),
-                    onTap: () => Navigator.of(context).pushNamed(
-                        '${r.Router.gameDetailRoute}/${game.name.replaceAll(' ', '+')}/${game.id}'),
-                  ),
-                ),
-              )),
-          TableCell(
-            verticalAlignment: TableCellVerticalAlignment.middle,
+          SizedBox(
+            width: 80,
             child: AppDefaultPadding(
               child: Container(
                 alignment: Alignment.centerRight,
@@ -243,8 +367,8 @@ class EnhancedListGamesDisplayPage extends NetworkWidget with AppPage {
               ),
             ),
           ),
-          TableCell(
-            verticalAlignment: TableCellVerticalAlignment.middle,
+          SizedBox(
+            width: 60,
             child: AppDefaultPadding(
               child: Container(
                 alignment: Alignment.centerRight,
@@ -252,12 +376,31 @@ class EnhancedListGamesDisplayPage extends NetworkWidget with AppPage {
               ),
             ),
           ),
-          TableCell(
-            verticalAlignment: TableCellVerticalAlignment.middle,
+          SizedBox(
+            width: 60,
             child: Center(
               child: MiniRatingBadge(rating: game.averageRating, size: 38),
             ),
           ),
-        ]);
+          if (isWide) ...[
+            IconButton(
+              icon: Icon(
+                isFav ? Icons.favorite : Icons.favorite_border,
+                color: isFav ? Colors.amber.shade700 : null,
+              ),
+              tooltip: isFav ? 'Unfavourite' : 'Favourite',
+              onPressed: () => widget.favouritesService.toggle(favGame),
+              visualDensity: VisualDensity.compact,
+            ),
+            IconButton(
+              icon: const Icon(Icons.visibility_off),
+              tooltip: 'Ignore',
+              onPressed: () => widget.ignoredService.toggle(favGame),
+              visualDensity: VisualDensity.compact,
+            ),
+          ],
+        ],
+      ),
+    );
   }
 }

--- a/lib/platform/web_or_tablet/web_random_game_display.dart
+++ b/lib/platform/web_or_tablet/web_random_game_display.dart
@@ -1,7 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:how_many_mobile_meeple/components/game_image_with_stats.dart';
 import 'package:how_many_mobile_meeple/components/recommendations_widget.dart';
+import 'package:how_many_mobile_meeple/favourites/game_action_buttons.dart';
+import 'package:how_many_mobile_meeple/favourites/ignored_games_service.dart';
 import 'package:how_many_mobile_meeple/platform/common/game_display_page.dart';
+import 'package:how_many_mobile_meeple/platform/router.dart' as r;
 import 'package:how_many_mobile_meeple/screen_tools.dart';
 
 import 'package:how_many_mobile_meeple/components/app_default_padding.dart';
@@ -26,7 +29,7 @@ class WebRandomGameDisplayPage extends GameDisplayPage {
     Game? game =
         hasPageRefreshed(model) ? cachedGames.random : cachedGames.lastRandom;
     if (game == null) {
-      return const Center(child: Text('No game available'));
+      return _buildExhaustedState(context, model);
     }
     updatePageRefreshedStatus(model);
     return SingleChildScrollView(
@@ -46,9 +49,52 @@ class WebRandomGameDisplayPage extends GameDisplayPage {
                   ),
                 ),
                 AppDefaultPadding(child: GameImageWithStats(game: game)),
-                shareButton(context, game),
+                GameActionButtons(game: game),
                 RecommendationsWidget(sourceGame: game, model: model),
               ]),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildExhaustedState(BuildContext context, AppModel model) {
+    final hasIgnored = (IgnoredGamesService.cached?.games.length ?? 0) > 0;
+
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.casino_outlined,
+                size: 64, color: Theme.of(context).colorScheme.secondary),
+            const SizedBox(height: 16),
+            Text(
+              "You've seen all available games",
+              style: Theme.of(context).textTheme.titleMedium,
+              textAlign: TextAlign.center,
+            ),
+            if (hasIgnored) ...[
+              const SizedBox(height: 12),
+              Text(
+                'Want to try again including your ignored games?',
+                textAlign: TextAlign.center,
+                style: Theme.of(context).textTheme.bodyMedium,
+              ),
+              const SizedBox(height: 16),
+              FilledButton.icon(
+                onPressed: () {
+                  final game = model.bggCache.randomIncludingIgnored();
+                  if (game != null) {
+                    Navigator.of(context).pushReplacementNamed(
+                        '${r.Router.gameDetailRoute}/${game.name.replaceAll(' ', '+')}/${game.id}');
+                  }
+                },
+                icon: const Icon(Icons.refresh),
+                label: const Text('Include ignored games'),
+              ),
+            ],
+          ],
         ),
       ),
     );

--- a/lib/screen_tools.dart
+++ b/lib/screen_tools.dart
@@ -3,6 +3,10 @@ import 'package:flutter/cupertino.dart';
 mixin ScreenTools {
   static const double fiftyPercentScreen = 0.5;
   static const double eightyPercentScreen = 0.8;
+  static const double wideBreakpoint = 1024;
+
+  bool isWideScreen(BuildContext context) =>
+      MediaQuery.of(context).size.width >= wideBreakpoint;
 
   Row pageFrameOutline(BuildContext context, Widget frameContent) {
     return Row(

--- a/lib/tour_tips/tour_tip_definitions.dart
+++ b/lib/tour_tips/tour_tip_definitions.dart
@@ -8,37 +8,16 @@ class TourTipDefinitions {
   static const String pageStep5 = 'step5';
 
   static const List<TourTip> all = [
-    // App bar tips (shown on first homepage visit)
+    // App bar tip (shown on first homepage visit)
     TourTip(
-      id: 'appbar_news',
-      title: 'Board Game News',
-      description: 'Tap here to read the latest board game news from the web.',
+      id: 'appbar_actions',
+      title: 'Your Top Bar',
+      description: '📰 News: latest board game news\n'
+          '⚡ Quick Pick: skip steps, pick a random game fast\n'
+          '❤️ Favourites: your saved games\n'
+          '⚙️ Settings: advanced options and filters',
       pageId: pageAppBar,
       order: 0,
-    ),
-    TourTip(
-      id: 'appbar_settings',
-      title: 'Settings Drawer',
-      description:
-          'Open the settings drawer for advanced options like expansions, recommended player counts, and advanced mode.',
-      pageId: pageAppBar,
-      order: 1,
-    ),
-    TourTip(
-      id: 'appbar_quick_pick',
-      title: 'Quick Pick',
-      description:
-          'Skip the steps and pick a random game fast. Choose players, time, or weight and go.',
-      pageId: pageAppBar,
-      order: 2,
-    ),
-    TourTip(
-      id: 'appbar_favourites',
-      title: 'Favourites',
-      description:
-          'View your favourite games here. Swipe right on a game in the list or tap the heart on a game page to add favourites.',
-      pageId: pageAppBar,
-      order: 3,
     ),
 
     // Step 2 tips

--- a/lib/tour_tips/tour_tip_definitions.dart
+++ b/lib/tour_tips/tour_tip_definitions.dart
@@ -32,6 +32,14 @@ class TourTipDefinitions {
       pageId: pageAppBar,
       order: 2,
     ),
+    TourTip(
+      id: 'appbar_favourites',
+      title: 'Favourites',
+      description:
+          'View your favourite games here. Swipe right on a game in the list or tap the heart on a game page to add favourites.',
+      pageId: pageAppBar,
+      order: 3,
+    ),
 
     // Step 2 tips
     TourTip(

--- a/lib/tour_tips/tour_tip_keys.dart
+++ b/lib/tour_tips/tour_tip_keys.dart
@@ -3,14 +3,8 @@ import 'tour_tip_definitions.dart';
 
 class TourTipKeys {
   // App bar
-  static final GlobalKey appBarNewsButton =
-      GlobalKey(debugLabel: 'appbar_news');
-  static final GlobalKey appBarSettingsButton =
-      GlobalKey(debugLabel: 'appbar_settings');
-  static final GlobalKey appBarQuickPick =
-      GlobalKey(debugLabel: 'appbar_quick_pick');
-  static final GlobalKey appBarFavourites =
-      GlobalKey(debugLabel: 'appbar_favourites');
+  static final GlobalKey appBarActions =
+      GlobalKey(debugLabel: 'appbar_actions');
 
   // Step 2
   static final GlobalKey playerSlider =
@@ -38,10 +32,7 @@ class TourTipKeys {
     switch (pageId) {
       case TourTipDefinitions.pageAppBar:
         return {
-          'appbar_news': appBarNewsButton,
-          'appbar_settings': appBarSettingsButton,
-          'appbar_quick_pick': appBarQuickPick,
-          'appbar_favourites': appBarFavourites,
+          'appbar_actions': appBarActions,
         };
       case TourTipDefinitions.pageStep2:
         return {

--- a/lib/tour_tips/tour_tip_keys.dart
+++ b/lib/tour_tips/tour_tip_keys.dart
@@ -9,6 +9,8 @@ class TourTipKeys {
       GlobalKey(debugLabel: 'appbar_settings');
   static final GlobalKey appBarQuickPick =
       GlobalKey(debugLabel: 'appbar_quick_pick');
+  static final GlobalKey appBarFavourites =
+      GlobalKey(debugLabel: 'appbar_favourites');
 
   // Step 2
   static final GlobalKey playerSlider =
@@ -39,6 +41,7 @@ class TourTipKeys {
           'appbar_news': appBarNewsButton,
           'appbar_settings': appBarSettingsButton,
           'appbar_quick_pick': appBarQuickPick,
+          'appbar_favourites': appBarFavourites,
         };
       case TourTipDefinitions.pageStep2:
         return {

--- a/lib/tour_tips/tour_tip_service.dart
+++ b/lib/tour_tips/tour_tip_service.dart
@@ -70,36 +70,14 @@ class TourTipService {
       return;
     }
 
-    final targetFocusList = _buildTargets(unseen, targets);
-    if (targetFocusList.isEmpty) {
-      _finishAndDrainQueue();
-      return;
-    }
+    await _showTipsSequentially(
+      context: context,
+      tips: unseen,
+      targets: targets,
+    );
 
-    final showCompleter = Completer<void>();
-
-    _activeMark = TutorialCoachMark(
-      targets: targetFocusList,
-      colorShadow: Colors.black,
-      opacityShadow: 0.8,
-      paddingFocus: 10,
-      hideSkip: true,
-      onFinish: () async {
-        await _markTipsAsSeen(unseen);
-        _activeMark = null;
-        _finishAndDrainQueue();
-        showCompleter.complete();
-      },
-      onSkip: () {
-        _markTipsAsSeen(unseen);
-        _activeMark = null;
-        _finishAndDrainQueue();
-        showCompleter.complete();
-        return true;
-      },
-    )..show(context: context);
-
-    await showCompleter.future;
+    await _markTipsAsSeen(unseen);
+    _finishAndDrainQueue();
   }
 
   void _finishAndDrainQueue() {
@@ -127,22 +105,174 @@ class TourTipService {
     return math.max(padding, 4);
   }
 
-  List<TargetFocus> _buildTargets(
-    List<TourTip> tips,
-    Map<String, GlobalKey> targets,
-  ) {
-    final result = <TargetFocus>[];
+  ContentAlign _contentAlignForKey(GlobalKey key) {
+    final renderBox = key.currentContext?.findRenderObject() as RenderBox?;
+    if (renderBox == null) return ContentAlign.bottom;
+    final position = renderBox.localToGlobal(Offset.zero);
+    final screenHeight = MediaQuery.of(key.currentContext!).size.height;
+    return position.dy > screenHeight * 0.5
+        ? ContentAlign.top
+        : ContentAlign.bottom;
+  }
 
+  Future<void> _ensureVisible(GlobalKey key) async {
+    final ctx = key.currentContext;
+    if (ctx == null) return;
+    await Scrollable.ensureVisible(
+      ctx,
+      duration: const Duration(milliseconds: 300),
+      alignmentPolicy: ScrollPositionAlignmentPolicy.keepVisibleAtEnd,
+    );
+  }
+
+  Future<void> _showTipsSequentially({
+    required BuildContext context,
+    required List<TourTip> tips,
+    required Map<String, GlobalKey> targets,
+  }) async {
     for (final tip in tips) {
       final key = targets[tip.id];
       if (key == null || key.currentContext == null) continue;
 
+      await _ensureVisible(key);
+      await Future.delayed(const Duration(milliseconds: 100));
+
+      if (!context.mounted || !isEnabled) break;
+      if (key.currentContext == null) continue;
+
       final screenWidth = MediaQuery.of(key.currentContext!).size.width;
       final padding = _cappedPaddingForKey(key, screenWidth);
+      final contentAlign = _contentAlignForKey(key);
 
-      result.add(
+      final completer = Completer<void>();
+
+      _activeMark = TutorialCoachMark(
+        targets: [
+          TargetFocus(
+            identify: tip.id,
+            keyTarget: key,
+            alignSkip: Alignment.topRight,
+            enableOverlayTab: true,
+            enableTargetTab: true,
+            paddingFocus: padding,
+            contents: [
+              TargetContent(
+                align: contentAlign,
+                builder: (ctx, controller) {
+                  final sw = MediaQuery.of(ctx).size.width;
+                  return _buildTipContent(sw, tip);
+                },
+              ),
+            ],
+          ),
+        ],
+        colorShadow: Colors.black,
+        opacityShadow: 0.8,
+        paddingFocus: 10,
+        hideSkip: true,
+        onFinish: () => completer.complete(),
+        onSkip: () {
+          completer.complete();
+          return true;
+        },
+      )..show(context: context);
+
+      await completer.future;
+      _activeMark = null;
+
+      if (!context.mounted || !isEnabled) break;
+    }
+  }
+
+  Widget _buildTipContent(double screenWidth, TourTip tip) {
+    return Container(
+      constraints: BoxConstraints(maxWidth: screenWidth * 0.7),
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: Colors.black87,
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            tip.title,
+            style: const TextStyle(
+              color: Colors.white,
+              fontWeight: FontWeight.bold,
+              fontSize: 20,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            tip.description,
+            style: const TextStyle(
+              color: Colors.white,
+              fontSize: 15,
+            ),
+          ),
+          const SizedBox(height: 16),
+          Wrap(
+            alignment: WrapAlignment.spaceBetween,
+            spacing: 8,
+            runSpacing: 4,
+            children: [
+              const Text(
+                'Tap anywhere to continue',
+                style: TextStyle(
+                  color: Colors.white70,
+                  fontSize: 12,
+                  fontStyle: FontStyle.italic,
+                ),
+              ),
+              GestureDetector(
+                onTap: () => dismissAll(),
+                child: const Text(
+                  'Dismiss Tour',
+                  style: TextStyle(
+                    color: Colors.white70,
+                    fontSize: 12,
+                    decoration: TextDecoration.underline,
+                    decorationColor: Colors.white70,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<bool> showSingleTip({
+    required BuildContext context,
+    required GlobalKey key,
+    required String id,
+    required String title,
+    required String description,
+  }) async {
+    if (!isEnabled) return false;
+    if (key.currentContext == null) return false;
+
+    await _ensureVisible(key);
+    await Future.delayed(const Duration(milliseconds: 100));
+
+    if (!context.mounted || !isEnabled) return false;
+    if (key.currentContext == null) return false;
+
+    final tip =
+        TourTip(id: id, title: title, description: description, pageId: '');
+    final screenWidth = MediaQuery.of(key.currentContext!).size.width;
+    final padding = _cappedPaddingForKey(key, screenWidth);
+    final contentAlign = _contentAlignForKey(key);
+
+    final completer = Completer<void>();
+
+    _activeMark = TutorialCoachMark(
+      targets: [
         TargetFocus(
-          identify: tip.id,
+          identify: id,
           keyTarget: key,
           alignSkip: Alignment.topRight,
           enableOverlayTab: true,
@@ -150,75 +280,29 @@ class TourTipService {
           paddingFocus: padding,
           contents: [
             TargetContent(
-              align: ContentAlign.bottom,
-              builder: (context, controller) {
-                final screenWidth = MediaQuery.of(context).size.width;
-                return Container(
-                  constraints: BoxConstraints(maxWidth: screenWidth * 0.7),
-                  padding: const EdgeInsets.all(16),
-                  decoration: BoxDecoration(
-                    color: Colors.black87,
-                    borderRadius: BorderRadius.circular(12),
-                  ),
-                  child: Column(
-                    mainAxisSize: MainAxisSize.min,
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        tip.title,
-                        style: const TextStyle(
-                          color: Colors.white,
-                          fontWeight: FontWeight.bold,
-                          fontSize: 20,
-                        ),
-                      ),
-                      const SizedBox(height: 8),
-                      Text(
-                        tip.description,
-                        style: const TextStyle(
-                          color: Colors.white,
-                          fontSize: 15,
-                        ),
-                      ),
-                      const SizedBox(height: 16),
-                      Wrap(
-                        alignment: WrapAlignment.spaceBetween,
-                        spacing: 8,
-                        runSpacing: 4,
-                        children: [
-                          const Text(
-                            'Tap anywhere to continue',
-                            style: TextStyle(
-                              color: Colors.white70,
-                              fontSize: 12,
-                              fontStyle: FontStyle.italic,
-                            ),
-                          ),
-                          GestureDetector(
-                            onTap: () => dismissAll(),
-                            child: const Text(
-                              'Dismiss Tour',
-                              style: TextStyle(
-                                color: Colors.white70,
-                                fontSize: 12,
-                                decoration: TextDecoration.underline,
-                                decorationColor: Colors.white70,
-                              ),
-                            ),
-                          ),
-                        ],
-                      ),
-                    ],
-                  ),
-                );
+              align: contentAlign,
+              builder: (ctx, controller) {
+                final sw = MediaQuery.of(ctx).size.width;
+                return _buildTipContent(sw, tip);
               },
             ),
           ],
         ),
-      );
-    }
+      ],
+      colorShadow: Colors.black,
+      opacityShadow: 0.8,
+      paddingFocus: 10,
+      hideSkip: true,
+      onFinish: () => completer.complete(),
+      onSkip: () {
+        completer.complete();
+        return true;
+      },
+    )..show(context: context);
 
-    return result;
+    await completer.future;
+    _activeMark = null;
+    return true;
   }
 
   Future<void> _markTipsAsSeen(List<TourTip> tips) async {

--- a/test/favourites/game_list_service_test.dart
+++ b/test/favourites/game_list_service_test.dart
@@ -1,0 +1,159 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:how_many_mobile_meeple/favourites/favourite_game.dart';
+import 'package:how_many_mobile_meeple/favourites/favourites_service.dart';
+import 'package:how_many_mobile_meeple/favourites/ignored_games_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    FavouritesService.resetForTesting();
+    IgnoredGamesService.resetForTesting();
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  final game1 = FavouriteGame(id: 1, name: 'Catan', thumbnail: null);
+  final game2 = FavouriteGame(id: 2, name: 'Pandemic', thumbnail: null);
+  final game3 = FavouriteGame(id: 3, name: 'Wingspan', thumbnail: null);
+
+  group('FavouritesService', () {
+    test('starts empty', () async {
+      final service = await FavouritesService.instance();
+      expect(service.games, isEmpty);
+    });
+
+    test('toggle adds a game', () async {
+      final service = await FavouritesService.instance();
+      service.toggle(game1);
+      expect(service.contains(1), isTrue);
+      expect(service.games.length, 1);
+    });
+
+    test('toggle removes a game that is already added', () async {
+      final service = await FavouritesService.instance();
+      service.toggle(game1);
+      service.toggle(game1);
+      expect(service.contains(1), isFalse);
+      expect(service.games, isEmpty);
+    });
+
+    test('remove removes a game by id', () async {
+      final service = await FavouritesService.instance();
+      service.toggle(game1);
+      service.toggle(game2);
+      service.remove(1);
+      expect(service.contains(1), isFalse);
+      expect(service.contains(2), isTrue);
+    });
+
+    test('contains returns false for unknown id', () async {
+      final service = await FavouritesService.instance();
+      expect(service.contains(999), isFalse);
+    });
+
+    test('new games are inserted at the front', () async {
+      final service = await FavouritesService.instance();
+      service.toggle(game1);
+      service.toggle(game2);
+      expect(service.games.first.id, 2);
+    });
+
+    test('notifies listeners on toggle', () async {
+      final service = await FavouritesService.instance();
+      var notified = false;
+      service.addListener(() => notified = true);
+      service.toggle(game1);
+      expect(notified, isTrue);
+    });
+
+    test('notifies listeners on remove', () async {
+      final service = await FavouritesService.instance();
+      service.toggle(game1);
+      var notified = false;
+      service.addListener(() => notified = true);
+      service.remove(1);
+      expect(notified, isTrue);
+    });
+  });
+
+  group('IgnoredGamesService', () {
+    test('starts empty', () async {
+      final service = await IgnoredGamesService.instance();
+      expect(service.games, isEmpty);
+    });
+
+    test('toggle adds a game', () async {
+      final service = await IgnoredGamesService.instance();
+      service.toggle(game3);
+      expect(service.contains(3), isTrue);
+    });
+
+    test('toggle removes a game that is already added', () async {
+      final service = await IgnoredGamesService.instance();
+      service.toggle(game3);
+      service.toggle(game3);
+      expect(service.contains(3), isFalse);
+    });
+  });
+
+  group('mutual exclusivity', () {
+    test('adding to favourites removes from ignored', () async {
+      final favs = await FavouritesService.instance();
+      final ignored = await IgnoredGamesService.instance();
+
+      ignored.toggle(game1);
+      expect(ignored.contains(1), isTrue);
+
+      favs.toggle(game1);
+      expect(favs.contains(1), isTrue);
+      expect(ignored.contains(1), isFalse);
+    });
+
+    test('adding to ignored removes from favourites', () async {
+      final favs = await FavouritesService.instance();
+      final ignored = await IgnoredGamesService.instance();
+
+      favs.toggle(game2);
+      expect(favs.contains(2), isTrue);
+
+      ignored.toggle(game2);
+      expect(ignored.contains(2), isTrue);
+      expect(favs.contains(2), isFalse);
+    });
+
+    test('toggling off does not affect the other list', () async {
+      final favs = await FavouritesService.instance();
+      final ignored = await IgnoredGamesService.instance();
+
+      favs.toggle(game1);
+      favs.toggle(game1);
+      expect(favs.contains(1), isFalse);
+      expect(ignored.contains(1), isFalse);
+    });
+  });
+
+  group('persistence', () {
+    test('saves games to SharedPreferences', () async {
+      final service = await FavouritesService.instance();
+      service.toggle(game1);
+      service.toggle(game2);
+
+      final prefs = await SharedPreferences.getInstance();
+      final raw = prefs.getString('favourite_games');
+      expect(raw, isNotNull);
+      expect(raw, contains('Catan'));
+      expect(raw, contains('Pandemic'));
+    });
+
+    test('loads persisted games on init', () async {
+      SharedPreferences.setMockInitialValues({
+        'favourite_games': '[{"id":1,"name":"Catan","thumbnail":null}]',
+      });
+
+      final service = await FavouritesService.instance();
+      expect(service.contains(1), isTrue);
+      expect(service.games.length, 1);
+    });
+  });
+}

--- a/test/guided_flow/step1_select_source_test.dart
+++ b/test/guided_flow/step1_select_source_test.dart
@@ -23,8 +23,8 @@ void main() {
         ),
       );
 
-      // Switch to My Collection tab
-      await tester.tap(find.text('My Collection'));
+      // Switch to Collection tab
+      await tester.tap(find.text('Collection'));
       await tester.pump();
 
       // Find the Add Source button
@@ -53,8 +53,8 @@ void main() {
         ),
       );
 
-      // Switch to My Collection tab
-      await tester.tap(find.text('My Collection'));
+      // Switch to Collection tab
+      await tester.tap(find.text('Collection'));
       await tester.pump();
 
       // Find the text field
@@ -91,8 +91,8 @@ void main() {
         ),
       );
 
-      // Switch to My Collection tab
-      await tester.tap(find.text('My Collection'));
+      // Switch to Collection tab
+      await tester.tap(find.text('Collection'));
       await tester.pump();
 
       // Find the text field

--- a/test/platform/pages_end_drawer_test.dart
+++ b/test/platform/pages_end_drawer_test.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:how_many_mobile_meeple/favourites/favourites_service.dart';
+import 'package:how_many_mobile_meeple/favourites/game_list_page.dart';
+import 'package:how_many_mobile_meeple/favourites/ignored_games_service.dart';
+import 'package:how_many_mobile_meeple/model/model.dart';
+import 'package:how_many_mobile_meeple/tour_tips/tour_tip_service.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+Widget _buildTestApp(Widget page) {
+  return ChangeNotifierProvider<AppModel>.value(
+    value: AppModel(),
+    child: MaterialApp(home: page),
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    FavouritesService.resetForTesting();
+    IgnoredGamesService.resetForTesting();
+    TourTipService.resetForTesting();
+    SharedPreferences.setMockInitialValues({
+      'tour_tips_disabled': true,
+    });
+  });
+
+  group('All pages have an endDrawer', () {
+    testWidgets('favourites page has endDrawer', (tester) async {
+      await tester.pumpWidget(_buildTestApp(
+        GameListPage(
+          title: 'Favourites',
+          emptyIcon: Icons.favorite_border,
+          emptyTitle: 'No favourites yet',
+          emptyDescription: 'Swipe right on a game in the list.',
+          serviceFactory: FavouritesService.instance,
+        ),
+      ));
+      await tester.pumpAndSettle();
+
+      final scaffold = tester.widget<Scaffold>(find.byType(Scaffold).first);
+      expect(scaffold.endDrawer, isNotNull,
+          reason: 'Favourites page must have an endDrawer');
+    });
+
+    testWidgets('ignored games page has endDrawer', (tester) async {
+      await tester.pumpWidget(_buildTestApp(
+        GameListPage(
+          title: 'Ignored Games',
+          emptyIcon: Icons.visibility_off_outlined,
+          emptyTitle: 'No ignored games',
+          emptyDescription: 'Swipe left on a game in the list.',
+          serviceFactory: IgnoredGamesService.instance,
+        ),
+      ));
+      await tester.pumpAndSettle();
+
+      final scaffold = tester.widget<Scaffold>(find.byType(Scaffold).first);
+      expect(scaffold.endDrawer, isNotNull,
+          reason: 'Ignored games page must have an endDrawer');
+    });
+
+    testWidgets('GameListPage always includes endDrawer', (tester) async {
+      await tester.pumpWidget(_buildTestApp(
+        GameListPage(
+          title: 'Test List',
+          emptyIcon: Icons.star,
+          emptyTitle: 'Empty',
+          emptyDescription: 'No items',
+          serviceFactory: FavouritesService.instance,
+        ),
+      ));
+      await tester.pumpAndSettle();
+
+      final scaffold = tester.widget<Scaffold>(find.byType(Scaffold).first);
+      expect(scaffold.endDrawer, isNotNull,
+          reason: 'GameListPage must have an endDrawer');
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Adds favourites (heart) and ignored games system with swipe gestures on the list page (right = favourite, left = ignore)
- Favourites get 3x weight in random/quick pick; ignored games are excluded from selection
- Mutual exclusivity enforced: a game cannot be in both lists simultaneously
- Wide screen (>=1024px) shows favourite/ignore buttons on list rows; game detail and random pages show action button row
- Per-request "include ignored" prompt when all games are exhausted (not persistent)
- Includes tour tip for favourites button, reusable `isWideScreen()` breakpoint, and zebra-striped list pages

## Test plan
- [x] 159 tests pass (16 new GameListService tests + 3 endDrawer tests)
- [x] Zero analysis issues
- [x] Verify swipe gestures work on mobile viewport
- [x] Verify favourite/ignore buttons appear on wide viewport (>=1024px)
- [x] Verify random game excludes ignored, weights favourites
- [x] Verify mutual exclusivity between favourite and ignore
- [x] Verify "include ignored" prompt appears when all games ignored

Closes #60, closes #76