### PR TITLE
chore: fix version accumulation and use 30-day changelog

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -20,32 +20,36 @@ jobs:
       - name: Determine version bump
         id: bump
         run: |
-          MSG=$(git log -1 --pretty=%s)
-          echo "Commit: $MSG"
+          LATEST=$(git tag --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
+          if [ -z "$LATEST" ]; then
+            LATEST=$(git rev-list --max-parents=0 HEAD)
+          fi
 
-          # Skip version bump commits (prevent infinite loop)
-          if echo "$MSG" | grep -qiE '^\[skip ci\]|^chore: bump version'; then
+          COMMITS=$(git log "${LATEST}..HEAD" --pretty=%s)
+          echo "Commits since $LATEST:"
+          echo "$COMMITS"
+
+          # Filter out skip/docs commits
+          RELEVANT=$(echo "$COMMITS" | grep -viE '^\[skip ci\]|^chore: bump version|^docs(\(.*\))?:' || true)
+
+          if [ -z "$RELEVANT" ]; then
             echo "type=skip" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          # Skip doc-only commits
-          if echo "$MSG" | grep -qiE '^docs(\(.*\))?:'; then
-            echo "type=skip" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
+          MINOR_COUNT=$(echo "$RELEVANT" | grep -ciE '^feat(\(.*\))?:' || true)
+          PATCH_COUNT=$(echo "$RELEVANT" | grep -cviE '^feat(\(.*\))?:' || true)
 
-          if echo "$MSG" | grep -qiE '^feat(\(.*\))?:'; then
-            echo "type=minor" >> "$GITHUB_OUTPUT"
-          else
-            echo "type=patch" >> "$GITHUB_OUTPUT"
-          fi
+          echo "minor_count=$MINOR_COUNT" >> "$GITHUB_OUTPUT"
+          echo "patch_count=$PATCH_COUNT" >> "$GITHUB_OUTPUT"
+          echo "type=bump" >> "$GITHUB_OUTPUT"
 
       - name: Compute new version
         if: steps.bump.outputs.type != 'skip'
         id: version
         run: |
-          BUMP="${{ steps.bump.outputs.type }}"
+          MINOR_COUNT="${{ steps.bump.outputs.minor_count }}"
+          PATCH_COUNT="${{ steps.bump.outputs.patch_count }}"
 
           LATEST=$(git tag --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
           if [ -z "$LATEST" ]; then
@@ -57,11 +61,11 @@ jobs:
           MINOR=$(echo "$LATEST" | sed 's/v//' | cut -d. -f2)
           PATCH=$(echo "$LATEST" | sed 's/v//' | cut -d. -f3)
 
-          if [ "$BUMP" = "minor" ]; then
-            MINOR=$((MINOR + 1))
-            PATCH=0
+          if [ "$MINOR_COUNT" -gt 0 ]; then
+            MINOR=$((MINOR + MINOR_COUNT))
+            PATCH=$PATCH_COUNT
           else
-            PATCH=$((PATCH + 1))
+            PATCH=$((PATCH + PATCH_COUNT))
           fi
 
           NEW_TAG="v${MAJOR}.${MINOR}.${PATCH}"

--- a/lib/about_page.dart
+++ b/lib/about_page.dart
@@ -41,8 +41,7 @@ class AboutPage extends StatelessWidget {
               const SizedBox(height: 24),
               _buildDescription(context),
               const SizedBox(height: 24),
-              _buildRecentChanges(
-                  context, data['since_version'], recentChanges),
+              _buildRecentChanges(context, recentChanges),
               const SizedBox(height: 24),
               _buildUpcoming(context, upcoming),
               const SizedBox(height: 24),
@@ -103,8 +102,7 @@ class AboutPage extends StatelessWidget {
     );
   }
 
-  Widget _buildRecentChanges(
-      BuildContext context, String sinceVersion, List<dynamic> changes) {
+  Widget _buildRecentChanges(BuildContext context, List<dynamic> changes) {
     return Card(
       child: Padding(
         padding: const EdgeInsets.all(16),
@@ -112,7 +110,7 @@ class AboutPage extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text(
-              "What's New (since $sinceVersion)",
+              "What's New",
               style: Theme.of(context).textTheme.titleMedium?.copyWith(
                     fontWeight: FontWeight.bold,
                   ),

--- a/lib/assets/about_data.json
+++ b/lib/assets/about_data.json
@@ -1,6 +1,5 @@
 {
   "version": "2.10.1",
-  "since_version": "v2.9.0",
   "recent_changes": [
     {
       "type": "fix",
@@ -16,6 +15,186 @@
       "type": "feat",
       "scope": "",
       "description": "add Quick Pick for fast random game selection"
+    },
+    {
+      "type": "feat",
+      "scope": "",
+      "description": "cache drawer preferences and hide empty game stats"
+    },
+    {
+      "type": "fix",
+      "scope": "",
+      "description": "handle null fields in hot games API response"
+    },
+    {
+      "type": "fix",
+      "scope": "",
+      "description": "guard null preference delete and cache StoredPreferences instance"
+    },
+    {
+      "type": "fix",
+      "scope": "",
+      "description": "use GitHub Actions API for issues instead of HTTP request"
+    },
+    {
+      "type": "fix",
+      "scope": "",
+      "description": "handle GitHub API timeout in about data generation"
+    },
+    {
+      "type": "fix",
+      "scope": "",
+      "description": "load saved sources on refresh and show friendly empty state"
+    },
+    {
+      "type": "fix",
+      "scope": "",
+      "description": "share button on random game page and remove false fallback dialog"
+    },
+    {
+      "type": "feat",
+      "scope": "",
+      "description": "auto-generate about page data in CI on tag release"
+    },
+    {
+      "type": "feat",
+      "scope": "",
+      "description": "add about page with version info, upcoming features, and contributors"
+    },
+    {
+      "type": "feat",
+      "scope": "",
+      "description": "replace collection/geeklist toggle with auto-detected leading icon"
+    },
+    {
+      "type": "fix",
+      "scope": "",
+      "description": "compact step 1 tabs to prevent text wrapping on mobile"
+    },
+    {
+      "type": "fix",
+      "scope": "",
+      "description": "center loading screen on mobile viewports"
+    },
+    {
+      "type": "feat",
+      "scope": "",
+      "description": "add tour tips, trending games, fun facts, and remove legacy mobile"
+    },
+    {
+      "type": "feat",
+      "scope": "",
+      "description": "redesign list pages with thumbnails, stats, rating badges, and sort indicators"
+    },
+    {
+      "type": "feat",
+      "scope": "",
+      "description": "add rating badge to game image overlay"
+    },
+    {
+      "type": "feat",
+      "scope": "",
+      "description": "add game detail page with cached API, share permalink, and image alignment"
+    },
+    {
+      "type": "fix",
+      "scope": "",
+      "description": "stale cache served after removing a collection/geeklist"
+    },
+    {
+      "type": "fix",
+      "scope": "",
+      "description": "cache invalidation & url reload stopping user changes"
+    },
+    {
+      "type": "feat",
+      "scope": "",
+      "description": "prefetch cache warming for collections and geeklists"
+    },
+    {
+      "type": "feat",
+      "scope": "",
+      "description": "replace max complexity filter with around-complexity filter"
+    },
+    {
+      "type": "feat",
+      "scope": "",
+      "description": "add Board Game News link to app bar"
+    },
+    {
+      "type": "feat",
+      "scope": "",
+      "description": "swipe gestures, larger step hit targets, full-width advanced mode"
+    },
+    {
+      "type": "feat",
+      "scope": "",
+      "description": "PWA install banner and home screen prompt"
+    },
+    {
+      "type": "feat",
+      "scope": "",
+      "description": "add Finish button to guided flow for direct navigation to results"
+    },
+    {
+      "type": "feat",
+      "scope": "",
+      "description": "UI consistency improvements"
+    },
+    {
+      "type": "fix",
+      "scope": "",
+      "description": "update code to correct analysis warnings from flutter upgrade"
+    },
+    {
+      "type": "fix",
+      "scope": "",
+      "description": "upgrade Flutter version in CI to 3.44.x for Dart 3.12 compatibility"
+    },
+    {
+      "type": "fix",
+      "scope": "",
+      "description": "update GitHub Actions workflow for Flutter 3.0"
+    },
+    {
+      "type": "fix",
+      "scope": "",
+      "description": "enable Add Source button when text is entered"
+    },
+    {
+      "type": "fix",
+      "scope": "",
+      "description": "restore automatic ItemType detection for numeric IDs"
+    },
+    {
+      "type": "fix",
+      "scope": "",
+      "description": "add missing null assertion in router path extraction"
+    },
+    {
+      "type": "feat",
+      "scope": "",
+      "description": "add mock BGG API server for development"
+    },
+    {
+      "type": "feat",
+      "scope": "",
+      "description": "add BGG attribution and theme extensions"
+    },
+    {
+      "type": "feat",
+      "scope": "",
+      "description": "add guided flow UI for game selection"
+    },
+    {
+      "type": "fix",
+      "scope": "",
+      "description": "handle unknown setting keys gracefully"
+    },
+    {
+      "type": "fix",
+      "scope": "",
+      "description": "prevent race conditions in async data operations"
     }
   ],
   "upcoming": [
@@ -89,11 +268,6 @@
     {
       "number": 43,
       "title": "Compare Two Choices",
-      "labels": []
-    },
-    {
-      "number": 42,
-      "title": "Why This Game?",
       "labels": []
     },
     {

--- a/scripts/generate_about_data.py
+++ b/scripts/generate_about_data.py
@@ -46,38 +46,9 @@ def git(*args):
     return result.stdout.strip()
 
 
-def find_previous_minor_tag(version):
-    """Find the latest tag from the previous minor version.
-
-    E.g. if version is 2.8.1, find the highest 2.7.x tag.
-    """
-    match = re.match(r"^(\d+)\.(\d+)\.", version)
-    if not match:
-        return None
-
-    major = int(match.group(1))
-    minor = int(match.group(2))
-
-    tags_output = git("tag", "--list", "--sort=-version:refname")
-    tags = [t.strip() for t in tags_output.splitlines() if t.strip()]
-
-    prev_minor = minor - 1
-    prefix = f"v{major}.{prev_minor}."
-
-    for tag in tags:
-        if tag.startswith(prefix):
-            return tag
-
-    return None
-
-
-def get_recent_changes(version):
-    prev_tag = find_previous_minor_tag(version)
-    if not prev_tag:
-        return [], ""
-
-    log_range = f"{prev_tag}..HEAD"
-    log_output = git("log", log_range, "--format=%s")
+def get_recent_changes():
+    """Get all feat/fix commits from the last 30 days."""
+    log_output = git("log", "--since=30 days ago", "--format=%s")
     lines = [line.strip() for line in log_output.splitlines() if line.strip()]
 
     changes = []
@@ -94,7 +65,7 @@ def get_recent_changes(version):
                 "description": match.group(3).strip(),
             })
 
-    return changes, prev_tag
+    return changes
 
 
 def get_version():
@@ -125,12 +96,11 @@ def main():
         print("Fetching open issues from GitHub...")
         issues = fetch_github_issues()
 
-    print(f"Getting recent changes since previous minor (current: {version})...")
-    changes, since_tag = get_recent_changes(version)
+    print(f"Getting recent changes from last 30 days (current: {version})...")
+    changes = get_recent_changes()
 
     data = {
         "version": version,
-        "since_version": since_tag,
         "recent_changes": changes,
         "upcoming": issues,
     }
@@ -139,9 +109,9 @@ def main():
         json.dump(data, f, indent=2)
 
     print(f"\nWritten to: {OUTPUT}")
-    print(f"Version: {version} (changes since: {since_tag})")
+    print(f"Version: {version}")
 
-    print(f"\n--- Recent Changes since {since_tag} ({len(changes)}) ---")
+    print(f"\n--- What's New (last 30 days, {len(changes)}) ---")
     for change in changes:
         prefix = "+" if change["type"] == "feat" else "*"
         scope = f"({change['scope']}) " if change["scope"] else ""


### PR DESCRIPTION
## Summary
- Fix version bump script to accumulate across all PR commits (feat+fix+fix now correctly produces a minor+2 patch bump instead of just a single patch)
- Replace previous-minor-tag changelog lookup with a 30-day rolling window for the "What's New" section
- Remove `since_version` field from about data JSON and simplify the about page heading

## Test plan
- [x] `flutter test` — all 159 tests pass
- [x] `python scripts/generate_about_data.py` — produces correct 30-day changelog
- [x] `flutter analyze` — no issues