### PR TITLE
fix: mobile layout - title truncation and button overflow

### DIFF
--- a/lib/favourites/game_action_buttons.dart
+++ b/lib/favourites/game_action_buttons.dart
@@ -60,27 +60,26 @@ class _GameActionButtonsState extends State<GameActionButtons> {
         FavouriteGame(id: game.id, name: game.name, thumbnail: game.thumbnail);
     final isFav = _favService!.contains(game.id);
     final isIgnored = _ignoreService!.contains(game.id);
+    final compact = MediaQuery.of(context).size.width < 480;
 
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 8),
       child: Row(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
-          ElevatedButton.icon(
+          _actionButton(
+            context,
             onPressed: () => _favService!.toggle(favGame),
             icon: Icon(isFav ? Icons.favorite : Icons.favorite_border),
-            label: Text(isFav ? 'Unfavourite' : 'Favourite'),
-            style: ElevatedButton.styleFrom(
-              backgroundColor: isFav
-                  ? Colors.amber.shade700
-                  : Theme.of(context).colorScheme.secondary,
-              foregroundColor: Colors.white,
-              shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(30)),
-            ),
+            label: isFav ? 'Unfavourite' : 'Favourite',
+            compact: compact,
+            backgroundColor: isFav
+                ? Colors.amber.shade700
+                : Theme.of(context).colorScheme.secondary,
           ),
           const SizedBox(width: 12),
-          ElevatedButton.icon(
+          _actionButton(
+            context,
             onPressed: () {
               _ignoreService!.toggle(favGame);
               if (!isIgnored && Navigator.of(context).canPop()) {
@@ -88,30 +87,57 @@ class _GameActionButtonsState extends State<GameActionButtons> {
               }
             },
             icon: Icon(isIgnored ? Icons.visibility : Icons.visibility_off),
-            label: Text(isIgnored ? 'Unignore' : 'Ignore'),
-            style: ElevatedButton.styleFrom(
-              backgroundColor: isIgnored
-                  ? Theme.of(context).colorScheme.secondary
-                  : Theme.of(context).colorScheme.error,
-              foregroundColor: Colors.white,
-              shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(30)),
-            ),
+            label: isIgnored ? 'Unignore' : 'Ignore',
+            compact: compact,
+            backgroundColor: isIgnored
+                ? Theme.of(context).colorScheme.secondary
+                : Theme.of(context).colorScheme.error,
           ),
           const SizedBox(width: 12),
-          ElevatedButton.icon(
+          _actionButton(
+            context,
             onPressed: () => _share(context, game),
             icon: const Icon(Icons.share),
-            label: const Text('Share'),
-            style: ElevatedButton.styleFrom(
-              backgroundColor: Theme.of(context).colorScheme.secondary,
-              foregroundColor: Colors.white,
-              shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(30)),
-            ),
+            label: 'Share',
+            compact: compact,
+            backgroundColor: Theme.of(context).colorScheme.secondary,
           ),
         ],
       ),
+    );
+  }
+
+  Widget _actionButton(
+    BuildContext context, {
+    required VoidCallback onPressed,
+    required Widget icon,
+    required String label,
+    required bool compact,
+    required Color backgroundColor,
+  }) {
+    final style = ElevatedButton.styleFrom(
+      backgroundColor: backgroundColor,
+      foregroundColor: Colors.white,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(30)),
+    );
+
+    if (compact) {
+      return IconButton(
+        onPressed: onPressed,
+        icon: icon,
+        tooltip: label,
+        style: IconButton.styleFrom(
+          backgroundColor: backgroundColor,
+          foregroundColor: Colors.white,
+        ),
+      );
+    }
+
+    return ElevatedButton.icon(
+      onPressed: onPressed,
+      icon: icon,
+      label: Text(label),
+      style: style,
     );
   }
 

--- a/lib/how_many_meeple_app_bar.dart
+++ b/lib/how_many_meeple_app_bar.dart
@@ -30,11 +30,15 @@ class HowManyMeepleAppBar extends AppBar {
                           r.Router.homeRoute, (route) => false);
                     }
                   }),
+          titleSpacing: isHomePage ? null : 0,
           title: Column(
             mainAxisAlignment: MainAxisAlignment.center,
             crossAxisAlignment: CrossAxisAlignment.start,
             children: <Widget>[
-              Text(AppCommon.appTitle),
+              FittedBox(
+                fit: BoxFit.scaleDown,
+                child: Text(AppCommon.appTitle),
+              ),
               Text(
                 subtitle,
                 style: const TextStyle(fontSize: 12),
@@ -49,8 +53,9 @@ class HowManyMeepleAppBar extends AppBar {
               mainAxisSize: MainAxisSize.min,
               children: [
                 IconButton(
-                  icon: const Icon(Icons.newspaper),
+                  icon: const Icon(Icons.newspaper, size: 20),
                   tooltip: 'Board Game News',
+                  visualDensity: VisualDensity.compact,
                   onPressed: () => launchUrl(
                     Uri.parse('https://www.boardgamenews.co.uk/'),
                     mode: LaunchMode.externalApplication,
@@ -58,23 +63,26 @@ class HowManyMeepleAppBar extends AppBar {
                 ),
                 Builder(
                   builder: (ctx) => IconButton(
-                    icon: const Icon(Icons.bolt),
+                    icon: const Icon(Icons.bolt, size: 20),
                     tooltip: 'Quick Pick',
+                    visualDensity: VisualDensity.compact,
                     onPressed: () => QuickPickSheet.show(ctx),
                   ),
                 ),
                 Builder(
                   builder: (ctx) => IconButton(
-                    icon: const Icon(Icons.favorite),
+                    icon: const Icon(Icons.favorite, size: 20),
                     tooltip: 'Favourites',
+                    visualDensity: VisualDensity.compact,
                     onPressed: () =>
                         Navigator.of(ctx).pushNamed(r.Router.favouritesRoute),
                   ),
                 ),
                 if (hasSaveDialog && model != null)
                   IconButton(
-                    icon: const Icon(Icons.save),
+                    icon: const Icon(Icons.save, size: 20),
                     tooltip: 'Save Settings',
+                    visualDensity: VisualDensity.compact,
                     onPressed: () => showDialog(
                       context: context,
                       builder: (context) => SaveDialog(model: model),
@@ -82,8 +90,9 @@ class HowManyMeepleAppBar extends AppBar {
                   ),
                 Builder(
                   builder: (ctx) => IconButton(
-                    icon: const Icon(Icons.settings),
+                    icon: const Icon(Icons.settings, size: 20),
                     tooltip: 'Settings',
+                    visualDensity: VisualDensity.compact,
                     onPressed: () => Scaffold.of(ctx).openEndDrawer(),
                   ),
                 ),


### PR DESCRIPTION
## Summary
- App bar title uses FittedBox to scale down instead of truncating on narrow screens
- App bar icons reduced to 20px with compact density to reclaim title space
- Game detail action buttons switch to icon-only below 480px viewport width

## Test plan
- [x] All 159 tests pass
- [x] `flutter analyze` clean
- [x] Verify title displays fully on mobile-width viewport
- [x] Verify detail page buttons show as icons only on narrow screens