### PR TITLE
feat: shelf of shame (#77)

### DIFF
--- a/lib/api/http_retry_client.dart
+++ b/lib/api/http_retry_client.dart
@@ -1,0 +1,56 @@
+import 'package:http/http.dart' as http;
+
+typedef DelayFunction = Future<void> Function(Duration duration);
+
+class HttpRetryClient {
+  static const int _initialBackoffSeconds = 2;
+  static const int _maxBackoffSeconds = 30;
+  static const Duration _retryTimeout = Duration(seconds: 600);
+
+  static http.Client? _testClient;
+  static DelayFunction _delayFn = (d) => Future.delayed(d);
+
+  static void setTestClient(http.Client client) {
+    _testClient = client;
+  }
+
+  static void resetTestClient() {
+    _testClient = null;
+  }
+
+  static void setDelayFunction(DelayFunction fn) {
+    _delayFn = fn;
+  }
+
+  static void resetDelayFunction() {
+    _delayFn = (d) => Future.delayed(d);
+  }
+
+  static Future<http.Response> getWithRetry(
+    Uri url, {
+    Map<String, String>? headers,
+    Set<int> retryableStatuses = const {202},
+  }) async {
+    final deadline = DateTime.now().add(_retryTimeout);
+    int backoff = _initialBackoffSeconds;
+
+    while (true) {
+      final client = _testClient ?? http.Client();
+      try {
+        final response = await client.get(url, headers: headers);
+
+        if (!retryableStatuses.contains(response.statusCode) ||
+            DateTime.now().isAfter(deadline)) {
+          return response;
+        }
+
+        await _delayFn(Duration(seconds: backoff));
+        backoff = (backoff * 2).clamp(0, _maxBackoffSeconds);
+      } finally {
+        if (_testClient == null) {
+          client.close();
+        }
+      }
+    }
+  }
+}

--- a/lib/api/plays_service.dart
+++ b/lib/api/plays_service.dart
@@ -1,0 +1,53 @@
+import 'dart:convert';
+import 'package:how_many_mobile_meeple/api/http_retry_client.dart';
+import 'package:how_many_mobile_meeple/app_common.dart';
+import 'package:how_many_mobile_meeple/model/play_data.dart';
+
+class _CachedPlays {
+  final Map<int, PlayData> plays;
+  final int timestamp;
+
+  _CachedPlays(this.plays, this.timestamp);
+
+  bool get isStale =>
+      DateTime.now().millisecondsSinceEpoch - timestamp > _cacheDurationMs;
+
+  static const int _cacheDurationMs = 30 * 60 * 1000;
+}
+
+class PlaysService {
+  static final Map<String, _CachedPlays> _cache = {};
+
+  static void clearCache() {
+    _cache.clear();
+  }
+
+  static Future<Map<int, PlayData>> fetchPlays(String username) async {
+    final cached = _cache[username];
+    if (cached != null && !cached.isStale) {
+      return cached.plays;
+    }
+
+    final url = Uri.parse('${AppCommon.boardGameGeekProxyUrl}/plays/$username');
+    final response = await HttpRetryClient.getWithRetry(url);
+
+    if (response.statusCode == 200) {
+      final List<dynamic> jsonList = jsonDecode(response.body);
+      final Map<int, PlayData> plays = {};
+      for (final json in jsonList) {
+        final playData = PlayData.fromJson(json);
+        plays[playData.gameId] = playData;
+      }
+      _cache[username] =
+          _CachedPlays(plays, DateTime.now().millisecondsSinceEpoch);
+      return plays;
+    }
+
+    if (response.statusCode == 404) {
+      return {};
+    }
+
+    throw Exception(
+        'Failed to load plays for $username (${response.statusCode})');
+  }
+}

--- a/lib/components/board_game_item_input_widget.dart
+++ b/lib/components/board_game_item_input_widget.dart
@@ -27,32 +27,32 @@ class _BoardGameItemInputWidgetState extends State<BoardGameItemInputWidget> {
 
   @override
   Widget build(BuildContext context) {
-    var textFieldWidth = MediaQuery.of(context).size.width * 0.65;
-
     return Align(
         alignment: Alignment.centerLeft,
         child: AppDefaultPadding(
           child: Row(
             children: <Widget>[
-              Container(
-                height: 35,
-                width: textFieldWidth,
-                child: Consumer<AppModel>(
-                  builder: (context, model, child) => TextFormField(
-                    enabled:
-                        model.items.itemList.length < AppCommon.maxItemsFromBgg,
-                    controller: controller,
-                    decoration: InputDecoration(
-                      hintText: model.items.itemList.length <
-                              AppCommon.maxItemsFromBgg
-                          ? AppCommon.itemHintTextMessage
-                          : AppCommon.maxItemsMessage,
+              Expanded(
+                child: SizedBox(
+                  height: 35,
+                  child: Consumer<AppModel>(
+                    builder: (context, model, child) => TextFormField(
+                      enabled: model.items.itemList.length <
+                          AppCommon.maxItemsFromBgg,
+                      controller: controller,
+                      decoration: InputDecoration(
+                        hintText: model.items.itemList.length <
+                                AppCommon.maxItemsFromBgg
+                            ? AppCommon.itemHintTextMessage
+                            : AppCommon.maxItemsMessage,
+                      ),
                     ),
                   ),
                 ),
               ),
               Consumer<AppModel>(
-                builder: (context, model, child) => AppDefaultPadding(
+                builder: (context, model, child) => Padding(
+                  padding: const EdgeInsets.only(left: 8),
                   child: ElevatedButton(
                     child: const Text('Add'),
                     onPressed: () {

--- a/lib/components/board_game_item_list_widget.dart
+++ b/lib/components/board_game_item_list_widget.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:how_many_mobile_meeple/app_common.dart';
 import 'package:how_many_mobile_meeple/components/app_default_padding.dart';
 import 'package:how_many_mobile_meeple/model/item.dart';
@@ -60,18 +61,41 @@ class BoardGameItemListWidget extends StatelessWidget {
         title: Text(item.itemType == ItemType.hotList
             ? 'Trending Games'
             : _limitTitleLength(item.name)),
-        trailing: IconButton(
-          padding: const EdgeInsets.all(4),
-          constraints: const BoxConstraints(),
-          tooltip: 'Remove',
-          icon: Icon(
-            Icons.delete,
-            size: AppCommon.standardIconSize,
-            color: Theme.of(context).colorScheme.error,
-          ),
-          onPressed: () {
-            model.deleteItem(item);
-          },
+        trailing: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (item.itemType == ItemType.collection)
+              IconButton(
+                padding: const EdgeInsets.all(4),
+                constraints: const BoxConstraints(),
+                tooltip: model.primaryPlayer == item.name
+                    ? 'Primary player'
+                    : 'Set as primary player',
+                icon: FaIcon(
+                  FontAwesomeIcons.crown,
+                  size: 18,
+                  color: model.primaryPlayer == item.name
+                      ? Colors.amber
+                      : Colors.grey,
+                ),
+                onPressed: () {
+                  model.primaryPlayer = item.name;
+                },
+              ),
+            IconButton(
+              padding: const EdgeInsets.all(4),
+              constraints: const BoxConstraints(),
+              tooltip: 'Remove',
+              icon: Icon(
+                Icons.delete,
+                size: AppCommon.standardIconSize,
+                color: Theme.of(context).colorScheme.error,
+              ),
+              onPressed: () {
+                model.deleteItem(item);
+              },
+            ),
+          ],
         ),
       ),
     );

--- a/lib/components/feature_drawer.dart
+++ b/lib/components/feature_drawer.dart
@@ -1,0 +1,197 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:url_launcher/url_launcher.dart';
+import 'package:how_many_mobile_meeple/components/quick_pick_sheet.dart';
+import 'package:how_many_mobile_meeple/model/item.dart';
+import 'package:how_many_mobile_meeple/model/model.dart';
+import 'package:how_many_mobile_meeple/platform/router.dart' as r;
+import 'package:how_many_mobile_meeple/app_common.dart';
+
+class FeatureDrawer extends StatelessWidget {
+  const FeatureDrawer({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<AppModel>(
+      builder: (context, model, child) {
+        final hasSources = model.items.itemList.isNotEmpty;
+        final hasCollection = model.items.itemList
+            .any((item) => item.itemType == ItemType.collection);
+
+        return Drawer(
+          child: SafeArea(
+            child: ListView(
+              padding: EdgeInsets.zero,
+              children: [
+                _buildHeader(context),
+                _buildSectionTitle(context, 'Play'),
+                _buildItem(
+                  context,
+                  icon: Icons.bolt,
+                  label: 'Quick Pick',
+                  enabled: hasSources,
+                  onTap: () {
+                    Navigator.of(context).pop();
+                    QuickPickSheet.show(context);
+                  },
+                ),
+                _buildItem(
+                  context,
+                  icon: Icons.casino,
+                  label: 'Random Game',
+                  enabled: hasSources,
+                  onTap: () {
+                    Navigator.of(context).pop();
+                    final settings = r.Router.generateRouteSettings(
+                        r.Router.randomRoute, model);
+                    model.pageRefreshed = true;
+                    Navigator.of(context).pushReplacementNamed(
+                      settings.name!,
+                      arguments: settings.arguments,
+                    );
+                  },
+                ),
+                _buildItem(
+                  context,
+                  icon: Icons.format_list_numbered,
+                  label: 'View List',
+                  enabled: hasSources,
+                  onTap: () {
+                    Navigator.of(context).pop();
+                    final settings = r.Router.generateRouteSettings(
+                        r.Router.listRoute, model);
+                    model.pageRefreshed = true;
+                    Navigator.of(context).pushReplacementNamed(
+                      settings.name!,
+                      arguments: settings.arguments,
+                    );
+                  },
+                ),
+                const Divider(),
+                _buildSectionTitle(context, 'Discover'),
+                _buildItem(
+                  context,
+                  icon: Icons.shelves,
+                  label: 'Shelf of Shame',
+                  enabled: hasCollection,
+                  disabledMessage: 'Add a BGG collection first',
+                  onTap: () {
+                    Navigator.of(context).pop();
+                    final username = model.primaryPlayer ?? '';
+                    Navigator.of(context).pushNamed(
+                        '${r.Router.shelfOfShameRoute}/${Uri.encodeComponent(username)}');
+                  },
+                ),
+                const Divider(),
+                _buildSectionTitle(context, 'My Games'),
+                _buildItem(
+                  context,
+                  icon: Icons.favorite,
+                  label: 'Favourites',
+                  onTap: () {
+                    Navigator.of(context).pop();
+                    Navigator.of(context).pushNamed(r.Router.favouritesRoute);
+                  },
+                ),
+                _buildItem(
+                  context,
+                  icon: Icons.visibility_off,
+                  label: 'Ignored Games',
+                  onTap: () {
+                    Navigator.of(context).pop();
+                    Navigator.of(context).pushNamed(r.Router.ignoredRoute);
+                  },
+                ),
+                _buildItem(
+                  context,
+                  icon: Icons.newspaper,
+                  label: 'Board Game News',
+                  onTap: () {
+                    Navigator.of(context).pop();
+                    launchUrl(
+                      Uri.parse('https://www.boardgamenews.co.uk/'),
+                      mode: LaunchMode.externalApplication,
+                    );
+                  },
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildHeader(BuildContext context) {
+    return Container(
+      height: 80.0,
+      child: DrawerHeader(
+        padding: const EdgeInsets.only(left: 16),
+        margin: EdgeInsets.zero,
+        decoration: BoxDecoration(
+          color: Theme.of(context).colorScheme.primary,
+        ),
+        child: Align(
+          alignment: Alignment.centerLeft,
+          child: Text(
+            AppCommon.appTitle,
+            style: TextStyle(
+              color: Theme.of(context).colorScheme.onPrimary,
+              fontSize: 18,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSectionTitle(BuildContext context, String title) {
+    return Padding(
+      padding: const EdgeInsets.only(left: 16, top: 12, bottom: 4),
+      child: Text(
+        title,
+        style: Theme.of(context).textTheme.labelMedium?.copyWith(
+              color: Theme.of(context).colorScheme.primary,
+              fontWeight: FontWeight.bold,
+            ),
+      ),
+    );
+  }
+
+  Widget _buildItem(
+    BuildContext context, {
+    required IconData icon,
+    required String label,
+    required VoidCallback onTap,
+    bool enabled = true,
+    String disabledMessage = 'Add a source first',
+  }) {
+    return ListTile(
+      dense: true,
+      leading: Icon(icon,
+          size: 20,
+          color: enabled
+              ? null
+              : Theme.of(context).colorScheme.onSurface.withAlpha(100)),
+      title: Text(label,
+          style: TextStyle(
+            fontSize: 14,
+            color: enabled
+                ? null
+                : Theme.of(context).colorScheme.onSurface.withAlpha(100),
+          )),
+      onTap: enabled
+          ? onTap
+          : () {
+              Navigator.of(context).pop();
+              ScaffoldMessenger.of(context).showSnackBar(
+                SnackBar(
+                  content: Text(disabledMessage),
+                  duration: const Duration(seconds: 2),
+                ),
+              );
+            },
+    );
+  }
+}

--- a/lib/components/game_image_with_stats.dart
+++ b/lib/components/game_image_with_stats.dart
@@ -1,9 +1,11 @@
 import 'dart:math' as math;
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:how_many_mobile_meeple/components/platform_independent_image.dart';
 import 'package:how_many_mobile_meeple/components/rating_badge.dart';
 import 'package:how_many_mobile_meeple/model/game.dart';
+import 'package:how_many_mobile_meeple/model/model.dart';
 import 'package:how_many_mobile_meeple/screen_tools.dart';
 
 class GameImageWithStats extends StatelessWidget with ScreenTools {
@@ -85,77 +87,229 @@ class GameImageWithStats extends StatelessWidget with ScreenTools {
                   ),
                 ),
               ),
-            if (_hasRating)
-              Positioned(
-                right: 8,
-                top: 8,
-                child: _RatingBadge(rating: game.averageRating),
-              ),
-            Positioned(
-              right: 0,
-              bottom: 0,
-              child: Container(
-                decoration: BoxDecoration(
-                  color: Theme.of(context).colorScheme.primary.withAlpha(192),
-                  borderRadius: const BorderRadius.only(
-                    topLeft: Radius.circular(12),
-                  ),
-                  border: Border.all(color: Colors.white, width: 1.5),
-                  boxShadow: [
-                    BoxShadow(
-                      color: Colors.black.withAlpha(64),
-                      blurRadius: 8,
-                      offset: const Offset(0, 2),
-                    ),
-                  ],
-                ),
-                padding:
-                    const EdgeInsets.symmetric(vertical: 16, horizontal: 20),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    if (_hasPlayers) ...[
-                      _StatChip(
-                        icon: Icons.people,
-                        label: game.minPlayers == game.maxPlayers
-                            ? '${game.minPlayers} players'
-                            : '${game.minPlayers}-${game.maxPlayers} players',
-                      ),
-                      const SizedBox(height: 14),
-                    ],
-                    if (_hasPlaytime) ...[
-                      _StatChip(
-                        icon: Icons.timer,
-                        label: '${game.maxPlaytime} min',
-                      ),
-                      const SizedBox(height: 14),
-                    ],
-                    if (_hasWeight) ...[
-                      _StatChip(
-                        icon: Icons.fitness_center,
-                        label: '${game.averageWeight.toStringAsFixed(1)} / 5',
-                      ),
-                      const SizedBox(height: 14),
-                    ],
-                    MouseRegion(
-                      cursor: SystemMouseCursors.click,
-                      child: GestureDetector(
-                        onTap: () => launchUrl(Uri.parse(
-                            'https://www.boardgamegeek.com/boardgame/${game.id}')),
-                        child: const _StatChip(
-                          icon: Icons.open_in_new,
-                          label: 'BoardGameGeek',
+            Positioned.fill(
+              child: Consumer<AppModel>(
+                builder: (context, model, child) {
+                  final isNarrow = !isWideScreen(context);
+                  final hasCollection = model.playsLoaded;
+                  final isOwned = model.isInCollection(game.id);
+                  final playCount = model.getPlayCount(game.id);
+
+                  final panel = _StatsPanel(
+                    game: game,
+                    isNarrow: isNarrow,
+                    hasCollection: hasCollection,
+                    isOwned: isOwned,
+                    playCount: playCount,
+                    hasPlayers: _hasPlayers,
+                    hasPlaytime: _hasPlaytime,
+                    hasWeight: _hasWeight,
+                    hasRating: _hasRating,
+                    maxHeight: maxHeight,
+                  );
+
+                  return Stack(
+                    clipBehavior: Clip.none,
+                    children: [
+                      if (_hasRating && !panel.ratingWouldOverlap)
+                        Positioned(
+                          right: 8,
+                          top: 8,
+                          child: _RatingBadge(rating: game.averageRating),
                         ),
+                      Positioned(
+                        right: 0,
+                        bottom: 0,
+                        child: panel,
                       ),
-                    ),
-                  ],
-                ),
+                    ],
+                  );
+                },
               ),
             ),
           ],
         ),
       ),
+    );
+  }
+}
+
+class _StatsPanel extends StatelessWidget {
+  final Game game;
+  final bool isNarrow;
+  final bool hasCollection;
+  final bool isOwned;
+  final int playCount;
+  final bool hasPlayers;
+  final bool hasPlaytime;
+  final bool hasWeight;
+  final bool hasRating;
+  final double maxHeight;
+
+  const _StatsPanel({
+    required this.game,
+    required this.isNarrow,
+    required this.hasCollection,
+    required this.isOwned,
+    required this.playCount,
+    required this.hasPlayers,
+    required this.hasPlaytime,
+    required this.hasWeight,
+    required this.hasRating,
+    required this.maxHeight,
+  });
+
+  int get _statCount {
+    int count = 1; // BGG link always present
+    if (hasPlayers) count++;
+    if (hasPlaytime) count++;
+    if (hasWeight) count++;
+    if (hasCollection) {
+      count++; // plays
+      if (isOwned) count++;
+    }
+    return count;
+  }
+
+  bool get ratingWouldOverlap {
+    if (!hasRating) return false;
+    final rowHeight = isNarrow ? 22.0 : 28.0;
+    final spacing = isNarrow ? 8.0 : 14.0;
+    final padding = isNarrow ? 20.0 : 32.0;
+    final panelHeight =
+        (_statCount * rowHeight) + ((_statCount - 1) * spacing) + padding;
+    final badgeSize = game.averageRating >= 5.5 ? 72.0 : 56.0;
+    final badgeBottom = maxHeight - 8.0 - badgeSize;
+    final panelTop = maxHeight - panelHeight;
+    return panelTop <= badgeBottom + 8;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final showRatingInPanel = ratingWouldOverlap;
+
+    return Container(
+      constraints: BoxConstraints(
+        maxWidth: isNarrow ? 160 : 220,
+      ),
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.primary.withAlpha(192),
+        borderRadius: const BorderRadius.only(
+          topLeft: Radius.circular(12),
+        ),
+        border: Border.all(color: Colors.white, width: 1.5),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withAlpha(64),
+            blurRadius: 8,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      padding: EdgeInsets.symmetric(
+        vertical: isNarrow ? 10 : 16,
+        horizontal: isNarrow ? 12 : 20,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (showRatingInPanel) ...[
+            _InlineRatingChip(rating: game.averageRating, compact: isNarrow),
+            SizedBox(height: isNarrow ? 8 : 14),
+          ],
+          if (hasPlayers) ...[
+            _StatChip(
+              icon: Icons.people,
+              label: game.minPlayers == game.maxPlayers
+                  ? '${game.minPlayers}p'
+                  : '${game.minPlayers}-${game.maxPlayers}p',
+              compact: isNarrow,
+            ),
+            SizedBox(height: isNarrow ? 8 : 14),
+          ],
+          if (hasPlaytime) ...[
+            _StatChip(
+              icon: Icons.timer,
+              label: '${game.maxPlaytime} min',
+              compact: isNarrow,
+            ),
+            SizedBox(height: isNarrow ? 8 : 14),
+          ],
+          if (hasWeight) ...[
+            _StatChip(
+              icon: Icons.fitness_center,
+              label: '${game.averageWeight.toStringAsFixed(1)} / 5',
+              compact: isNarrow,
+            ),
+            SizedBox(height: isNarrow ? 8 : 14),
+          ],
+          if (hasCollection) ...[
+            _StatChip(
+              icon: Icons.play_arrow,
+              label: playCount > 0
+                  ? '$playCount play${playCount == 1 ? '' : 's'}'
+                  : 'Unplayed',
+              compact: isNarrow,
+            ),
+            SizedBox(height: isNarrow ? 8 : 14),
+            if (isOwned)
+              _StatChip(
+                icon: Icons.check_circle_outline,
+                label: 'Owned',
+                compact: isNarrow,
+              ),
+            if (isOwned) SizedBox(height: isNarrow ? 8 : 14),
+          ],
+          MouseRegion(
+            cursor: SystemMouseCursors.click,
+            child: GestureDetector(
+              onTap: () => launchUrl(Uri.parse(
+                  'https://www.boardgamegeek.com/boardgame/${game.id}')),
+              child: _StatChip(
+                icon: Icons.open_in_new,
+                label: isNarrow ? 'BGG' : 'BoardGameGeek',
+                compact: isNarrow,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _InlineRatingChip extends StatelessWidget {
+  final double rating;
+  final bool compact;
+
+  const _InlineRatingChip({required this.rating, this.compact = false});
+
+  @override
+  Widget build(BuildContext context) {
+    final (Color bgColor, _) = ratingColors(rating);
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Container(
+          width: compact ? 14 : 18,
+          height: compact ? 14 : 18,
+          decoration: BoxDecoration(
+            color: bgColor,
+            shape: BoxShape.circle,
+          ),
+          child: Icon(Icons.star, size: compact ? 10 : 12, color: Colors.white),
+        ),
+        SizedBox(width: compact ? 3 : 4),
+        Text(
+          rating.toStringAsFixed(1),
+          style: TextStyle(
+            color: Colors.white,
+            fontSize: compact ? 11 : 13,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+      ],
     );
   }
 }
@@ -275,22 +429,30 @@ class _StarPainter extends CustomPainter {
 class _StatChip extends StatelessWidget {
   final IconData icon;
   final String label;
+  final bool compact;
 
-  const _StatChip({required this.icon, required this.label});
+  const _StatChip({
+    required this.icon,
+    required this.label,
+    this.compact = false,
+  });
 
   @override
   Widget build(BuildContext context) {
     return Row(
       mainAxisSize: MainAxisSize.min,
       children: [
-        Icon(icon, color: Colors.white, size: 18),
-        const SizedBox(width: 4),
-        Text(
-          label,
-          style: const TextStyle(
-            color: Colors.white,
-            fontSize: 13,
-            fontWeight: FontWeight.w600,
+        Icon(icon, color: Colors.white, size: compact ? 14 : 18),
+        SizedBox(width: compact ? 3 : 4),
+        Flexible(
+          child: Text(
+            label,
+            style: TextStyle(
+              color: Colors.white,
+              fontSize: compact ? 11 : 13,
+              fontWeight: FontWeight.w600,
+            ),
+            overflow: TextOverflow.ellipsis,
           ),
         ),
       ],

--- a/lib/components/quick_pick_sheet.dart
+++ b/lib/components/quick_pick_sheet.dart
@@ -27,6 +27,7 @@ class _QuickPickSheetState extends State<QuickPickSheet> {
   int? _selectedPlayers;
   int? _selectedMaxTime;
   double? _selectedWeight;
+  bool _shelfOfShameOnly = false;
 
   @override
   void didChangeDependencies() {
@@ -57,6 +58,10 @@ class _QuickPickSheetState extends State<QuickPickSheet> {
         _weightOptions.containsValue(complexitySetting.value)) {
       _selectedWeight = complexitySetting.value as double;
     }
+
+    final sosSetting =
+        model.settings.setting(Settings.filterShelfOfShameOnly.name);
+    _shelfOfShameOnly = sosSetting.enabled && sosSetting.getBool();
   }
 
   static const Map<String, int> _playerOptions = {
@@ -80,86 +85,90 @@ class _QuickPickSheetState extends State<QuickPickSheet> {
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding: EdgeInsets.only(
-        left: 24,
-        right: 24,
-        top: 24,
-        bottom: MediaQuery.of(context).viewInsets.bottom + 24,
-      ),
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          Center(
-            child: Container(
-              width: 40,
-              height: 4,
-              decoration: BoxDecoration(
-                color: Theme.of(context).colorScheme.onSurfaceVariant,
-                borderRadius: BorderRadius.circular(2),
+    return SingleChildScrollView(
+      child: Padding(
+        padding: EdgeInsets.only(
+          left: 24,
+          right: 24,
+          top: 24,
+          bottom: MediaQuery.of(context).viewInsets.bottom + 24,
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Center(
+              child: Container(
+                width: 40,
+                height: 4,
+                decoration: BoxDecoration(
+                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                  borderRadius: BorderRadius.circular(2),
+                ),
               ),
             ),
-          ),
-          const SizedBox(height: 20),
-          Text(
-            'Quick Pick',
-            style: Theme.of(context).textTheme.headlineSmall?.copyWith(
-                  fontWeight: FontWeight.bold,
-                ),
-            textAlign: TextAlign.center,
-          ),
-          const SizedBox(height: 4),
-          Text(
-            'Pick what matters, skip what doesn\'t',
-            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                  color: Theme.of(context).colorScheme.onSurfaceVariant,
-                ),
-            textAlign: TextAlign.center,
-          ),
-          const SizedBox(height: 28),
-          _buildChipRow(
-            icon: Icons.people,
-            label: 'Players',
-            options: _playerOptions,
-            selected: _selectedPlayers,
-            onChanged: (value) => setState(() => _selectedPlayers = value),
-          ),
-          const SizedBox(height: 16),
-          _buildChipRow(
-            icon: Icons.schedule,
-            label: 'Time',
-            options: _timeOptions,
-            selected: _selectedMaxTime,
-            onChanged: (value) => setState(() => _selectedMaxTime = value),
-          ),
-          const SizedBox(height: 16),
-          _buildChipRow(
-            icon: Icons.fitness_center,
-            label: 'Weight',
-            options: _weightOptions,
-            selected: _selectedWeight,
-            onChanged: (value) => setState(() => _selectedWeight = value),
-          ),
-          const SizedBox(height: 28),
-          Consumer<AppModel>(
-            builder: (context, model, child) {
-              final hasSource = model.items.itemList.isNotEmpty;
-              return FilledButton.icon(
-                onPressed: hasSource ? () => _applyAndGo(context) : null,
-                icon: const Icon(Icons.casino, size: 24),
-                label: Text(
-                  hasSource ? 'Go!' : 'Add a source first',
-                  style: const TextStyle(
-                      fontSize: 16, fontWeight: FontWeight.bold),
-                ),
-                style: FilledButton.styleFrom(
-                  padding: const EdgeInsets.symmetric(vertical: 16),
-                ),
-              );
-            },
-          ),
-        ],
+            const SizedBox(height: 20),
+            Text(
+              'Quick Pick',
+              style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                    fontWeight: FontWeight.bold,
+                  ),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 4),
+            Text(
+              'Pick what matters, skip what doesn\'t',
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    color: Theme.of(context).colorScheme.onSurfaceVariant,
+                  ),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 28),
+            _buildChipRow(
+              icon: Icons.people,
+              label: 'Players',
+              options: _playerOptions,
+              selected: _selectedPlayers,
+              onChanged: (value) => setState(() => _selectedPlayers = value),
+            ),
+            const SizedBox(height: 16),
+            _buildChipRow(
+              icon: Icons.schedule,
+              label: 'Time',
+              options: _timeOptions,
+              selected: _selectedMaxTime,
+              onChanged: (value) => setState(() => _selectedMaxTime = value),
+            ),
+            const SizedBox(height: 16),
+            _buildChipRow(
+              icon: Icons.fitness_center,
+              label: 'Weight',
+              options: _weightOptions,
+              selected: _selectedWeight,
+              onChanged: (value) => setState(() => _selectedWeight = value),
+            ),
+            const SizedBox(height: 16),
+            _buildShelfOfShameToggle(context),
+            const SizedBox(height: 28),
+            Consumer<AppModel>(
+              builder: (context, model, child) {
+                final hasSource = model.items.itemList.isNotEmpty;
+                return FilledButton.icon(
+                  onPressed: hasSource ? () => _applyAndGo(context) : null,
+                  icon: const Icon(Icons.casino, size: 24),
+                  label: Text(
+                    hasSource ? 'Go!' : 'Add a source first',
+                    style: const TextStyle(
+                        fontSize: 16, fontWeight: FontWeight.bold),
+                  ),
+                  style: FilledButton.styleFrom(
+                    padding: const EdgeInsets.symmetric(vertical: 16),
+                  ),
+                );
+              },
+            ),
+          ],
+        ),
       ),
     );
   }
@@ -203,6 +212,61 @@ class _QuickPickSheetState extends State<QuickPickSheet> {
     );
   }
 
+  Widget _buildShelfOfShameToggle(BuildContext context) {
+    return Consumer<AppModel>(
+      builder: (context, model, child) {
+        final hasPrimaryPlayer = model.primaryPlayer != null;
+        return InkWell(
+          onTap: hasPrimaryPlayer
+              ? () => setState(() => _shelfOfShameOnly = !_shelfOfShameOnly)
+              : null,
+          borderRadius: BorderRadius.circular(8),
+          child: Container(
+            padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 4),
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(8),
+              border: Border.all(
+                color: _shelfOfShameOnly
+                    ? Theme.of(context).colorScheme.primary
+                    : Theme.of(context).colorScheme.outline.withAlpha(80),
+              ),
+              color: _shelfOfShameOnly
+                  ? Theme.of(context).colorScheme.primaryContainer.withAlpha(80)
+                  : null,
+            ),
+            child: Row(
+              children: [
+                Icon(Icons.shelves,
+                    size: 20,
+                    color: hasPrimaryPlayer
+                        ? Theme.of(context).colorScheme.primary
+                        : Theme.of(context).colorScheme.onSurfaceVariant),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    'Unplayed only',
+                    style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                          fontWeight: FontWeight.bold,
+                          color: hasPrimaryPlayer
+                              ? null
+                              : Theme.of(context).colorScheme.onSurfaceVariant,
+                        ),
+                  ),
+                ),
+                Switch(
+                  value: _shelfOfShameOnly,
+                  onChanged: hasPrimaryPlayer
+                      ? (value) => setState(() => _shelfOfShameOnly = value)
+                      : null,
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+
   void _applyAndGo(BuildContext context) {
     final model = AppModel.of(context, listen: false);
 
@@ -234,6 +298,12 @@ class _QuickPickSheetState extends State<QuickPickSheet> {
       complexitySetting.enabled = true;
       model.settings.updateSetting(complexitySetting);
     }
+
+    final sosSetting =
+        model.settings.setting(Settings.filterShelfOfShameOnly.name);
+    sosSetting.value = _shelfOfShameOnly;
+    sosSetting.enabled = _shelfOfShameOnly;
+    model.settings.updateSetting(sosSetting);
 
     model.invalidateCache();
     model.updateStore();

--- a/lib/components/shelf_of_shame_filter_widget.dart
+++ b/lib/components/shelf_of_shame_filter_widget.dart
@@ -1,0 +1,11 @@
+import 'package:flutter/material.dart';
+import 'package:how_many_mobile_meeple/components/unplayed_only_toggle.dart';
+
+class ShelfOfShameFilterWidget extends StatelessWidget {
+  const ShelfOfShameFilterWidget({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const UnplayedOnlyToggle(style: UnplayedToggleStyle.compact);
+  }
+}

--- a/lib/components/unplayed_only_toggle.dart
+++ b/lib/components/unplayed_only_toggle.dart
@@ -1,0 +1,141 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:how_many_mobile_meeple/model/model.dart';
+import 'package:how_many_mobile_meeple/model/settings.dart';
+
+enum UnplayedToggleStyle { compact, card }
+
+class UnplayedOnlyToggle extends StatelessWidget {
+  final UnplayedToggleStyle style;
+
+  const UnplayedOnlyToggle({
+    super.key,
+    this.style = UnplayedToggleStyle.card,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<AppModel>(
+      builder: (context, model, child) {
+        final hasPrimaryPlayer = model.primaryPlayer != null;
+        final setting =
+            model.settings.setting(Settings.filterShelfOfShameOnly.name);
+        final isActive = setting.enabled && setting.getBool();
+
+        void toggle(bool value) {
+          setting.value = value;
+          setting.enabled = value;
+          model.settings.updateSetting(setting);
+          model.updateStore();
+          model.invalidateCache();
+        }
+
+        if (style == UnplayedToggleStyle.compact) {
+          return _buildCompact(context, hasPrimaryPlayer, isActive, toggle);
+        }
+        return _buildCard(context, hasPrimaryPlayer, isActive, toggle);
+      },
+    );
+  }
+
+  Widget _buildCompact(BuildContext context, bool hasPrimaryPlayer,
+      bool isActive, ValueChanged<bool> onToggle) {
+    return Container(
+      height: 35,
+      color: isActive
+          ? Theme.of(context).colorScheme.primaryContainer
+          : Theme.of(context).colorScheme.primary.withValues(alpha: 0.25),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 8),
+            child: Row(
+              children: [
+                Icon(Icons.shelves,
+                    size: 16,
+                    color: isActive
+                        ? Theme.of(context).colorScheme.onPrimaryContainer
+                        : Theme.of(context).colorScheme.onSurfaceVariant),
+                const SizedBox(width: 6),
+                Text(
+                  'Unplayed Only (Shelf of Shame)',
+                  style: TextStyle(
+                    fontWeight: isActive ? FontWeight.bold : FontWeight.normal,
+                    color: isActive
+                        ? Theme.of(context).colorScheme.onPrimaryContainer
+                        : Theme.of(context).colorScheme.onSurfaceVariant,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          Switch(
+            value: isActive,
+            onChanged: hasPrimaryPlayer ? onToggle : null,
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildCard(BuildContext context, bool hasPrimaryPlayer, bool isActive,
+      ValueChanged<bool> onToggle) {
+    return InkWell(
+      onTap: hasPrimaryPlayer ? () => onToggle(!isActive) : null,
+      borderRadius: BorderRadius.circular(8),
+      child: Container(
+        padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 12),
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(8),
+          border: Border.all(
+            color: isActive
+                ? Theme.of(context).colorScheme.primary
+                : Theme.of(context).colorScheme.outline.withAlpha(80),
+          ),
+          color: isActive
+              ? Theme.of(context).colorScheme.primaryContainer.withAlpha(80)
+              : null,
+        ),
+        child: Row(
+          children: [
+            Icon(Icons.shelves,
+                size: 20,
+                color: hasPrimaryPlayer
+                    ? Theme.of(context).colorScheme.primary
+                    : Theme.of(context).colorScheme.onSurfaceVariant),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    'Unplayed only',
+                    style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                          fontWeight: FontWeight.bold,
+                          color: hasPrimaryPlayer
+                              ? null
+                              : Theme.of(context).colorScheme.onSurfaceVariant,
+                        ),
+                  ),
+                  Text(
+                    hasPrimaryPlayer
+                        ? 'Only show games from your shelf of shame'
+                        : 'Set a primary player to enable',
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                          color: Theme.of(context).colorScheme.onSurfaceVariant,
+                        ),
+                  ),
+                ],
+              ),
+            ),
+            Switch(
+              value: isActive,
+              onChanged: hasPrimaryPlayer ? onToggle : null,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/favourites/game_list_page.dart
+++ b/lib/favourites/game_list_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:how_many_mobile_meeple/app_page.dart';
+import 'package:how_many_mobile_meeple/components/feature_drawer.dart';
 import 'package:how_many_mobile_meeple/components/platform_independent_image.dart';
 import 'package:how_many_mobile_meeple/how_many_meeple_app_bar.dart';
 import 'package:how_many_mobile_meeple/platform/router.dart' as r;
@@ -55,6 +56,7 @@ class _GameListPageState extends State<GameListPage> with AppPage {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: HowManyMeepleAppBar(widget.title, context: context),
+      drawer: const FeatureDrawer(),
       endDrawer: pageDrawer(context),
       body: _service == null
           ? const Center(child: CircularProgressIndicator())

--- a/lib/guided_flow/advanced_mode_widget.dart
+++ b/lib/guided_flow/advanced_mode_widget.dart
@@ -10,6 +10,7 @@ import 'package:how_many_mobile_meeple/components/complexity_filter_widget.dart'
 import 'package:how_many_mobile_meeple/components/mechanic_filter_widget.dart';
 import 'package:how_many_mobile_meeple/components/player_filter_widget.dart';
 import 'package:how_many_mobile_meeple/components/rating_filter_widget.dart';
+import 'package:how_many_mobile_meeple/components/shelf_of_shame_filter_widget.dart';
 import 'package:how_many_mobile_meeple/components/time_filter_widget.dart';
 
 class AdvancedModeWidget extends StatelessWidget {
@@ -35,6 +36,8 @@ class AdvancedModeWidget extends StatelessWidget {
         const RatingFilterWidget(),
         const SizedBox(height: 8),
         const MechanicFilterWidget(),
+        const SizedBox(height: 8),
+        const ShelfOfShameFilterWidget(),
       ],
     );
   }

--- a/lib/guided_flow/step1_select_source.dart
+++ b/lib/guided_flow/step1_select_source.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:how_many_mobile_meeple/model/model.dart';
@@ -417,6 +418,9 @@ class _Step1SelectSourceState extends State<Step1SelectSource> {
       label = item.name;
     }
 
+    final isPrimary = item.itemType == ItemType.collection &&
+        model.primaryPlayer == item.name;
+
     return Padding(
       padding: const EdgeInsets.only(bottom: 8),
       child: Container(
@@ -447,6 +451,18 @@ class _Step1SelectSourceState extends State<Step1SelectSource> {
                     ),
               ),
             ),
+            if (item.itemType == ItemType.collection)
+              IconButton(
+                icon: FaIcon(
+                  FontAwesomeIcons.crown,
+                  size: 16,
+                  color: isPrimary ? Colors.amber : Colors.grey,
+                ),
+                onPressed: () {
+                  model.primaryPlayer = item.name;
+                },
+                tooltip: isPrimary ? 'Primary player' : 'Set as primary player',
+              ),
             IconButton(
               icon: const Icon(Icons.close, size: 20),
               onPressed: () {

--- a/lib/guided_flow/step4_game_style.dart
+++ b/lib/guided_flow/step4_game_style.dart
@@ -5,6 +5,7 @@ import 'package:how_many_mobile_meeple/model/settings.dart';
 import 'package:how_many_mobile_meeple/components/app_choice_chip.dart';
 import 'package:how_many_mobile_meeple/components/step_header_card.dart';
 import 'package:how_many_mobile_meeple/components/info_message_box.dart';
+import 'package:how_many_mobile_meeple/components/unplayed_only_toggle.dart';
 import 'package:how_many_mobile_meeple/tour_tips/tour_tip_keys.dart';
 
 /// Step 4: Game Style
@@ -258,6 +259,12 @@ class _Step4GameStyleState extends State<Step4GameStyle> {
                       ? 'Skip mechanics to see all game types'
                       : '${selectedMechanics.length} mechanic(s) selected',
                 ),
+
+                const SizedBox(height: 32),
+                const Divider(),
+                const SizedBox(height: 24),
+
+                const UnplayedOnlyToggle(),
               ],
             ),
           ),

--- a/lib/guided_flow/step5_final_actions.dart
+++ b/lib/guided_flow/step5_final_actions.dart
@@ -127,6 +127,26 @@ class Step5FinalActions extends StatelessWidget {
 
                 const SizedBox(height: 12),
 
+                // Shelf of Shame
+                OutlinedButton.icon(
+                  onPressed: () {
+                    final username = model.primaryPlayer ?? '';
+                    Navigator.of(context).pushNamed(
+                        '${r.Router.shelfOfShameRoute}/${Uri.encodeComponent(username)}');
+                  },
+                  icon: const Icon(Icons.shelves, size: 24),
+                  label: const Text(
+                    'Shelf of Shame',
+                    style: TextStyle(fontSize: 16),
+                  ),
+                  style: OutlinedButton.styleFrom(
+                    padding: const EdgeInsets.symmetric(
+                        vertical: 20, horizontal: 24),
+                  ),
+                ),
+
+                const SizedBox(height: 12),
+
                 // Tertiary action - Review Settings
                 OutlinedButton.icon(
                   onPressed: () {

--- a/lib/guided_flow_homepage.dart
+++ b/lib/guided_flow_homepage.dart
@@ -4,6 +4,7 @@ import 'package:how_many_mobile_meeple/model/model.dart';
 import 'package:how_many_mobile_meeple/how_many_meeple_app_bar.dart';
 import 'package:how_many_mobile_meeple/app_common.dart';
 import 'package:how_many_mobile_meeple/app_page.dart';
+import 'package:how_many_mobile_meeple/components/feature_drawer.dart';
 import 'package:how_many_mobile_meeple/components/quick_pick_sheet.dart';
 import 'package:how_many_mobile_meeple/guided_flow/step1_select_source.dart';
 import 'package:how_many_mobile_meeple/guided_flow/step2_whos_playing.dart';
@@ -90,6 +91,8 @@ class _GuidedFlowHomePageState extends State<GuidedFlowHomePage> {
             model: model,
             context: context,
           ),
+          drawer: const FeatureDrawer(),
+          drawerEdgeDragWidth: 60,
           endDrawer: widget.pageDrawer(context),
           body: Column(
             children: [
@@ -114,17 +117,17 @@ class _GuidedFlowHomePageState extends State<GuidedFlowHomePage> {
 
   /// Builds the guided flow with step progression
   Widget _buildGuidedFlow(BuildContext context) {
-    return GestureDetector(
-      onHorizontalDragEnd: (details) {
-        final velocity = details.primaryVelocity ?? 0;
+    return _DrawerAwareSwipeDetector(
+      onSwipeLeft: () {
         final model = AppModel.of(context, listen: false);
-        if (velocity < -300 && _currentStep < _totalSteps - 1) {
+        if (_currentStep < _totalSteps - 1) {
           final canProceed =
               _currentStep != 0 || model.items.itemList.isNotEmpty;
           if (canProceed) setState(() => _currentStep++);
-        } else if (velocity > 300 && _currentStep > 0) {
-          setState(() => _currentStep--);
         }
+      },
+      onSwipeRight: () {
+        if (_currentStep > 0) setState(() => _currentStep--);
       },
       child: SingleChildScrollView(
         child: Padding(
@@ -458,6 +461,49 @@ class _GuidedFlowHomePageState extends State<GuidedFlowHomePage> {
           ),
         );
       },
+    );
+  }
+}
+
+class _DrawerAwareSwipeDetector extends StatefulWidget {
+  final VoidCallback onSwipeLeft;
+  final VoidCallback onSwipeRight;
+  final Widget child;
+
+  const _DrawerAwareSwipeDetector({
+    required this.onSwipeLeft,
+    required this.onSwipeRight,
+    required this.child,
+  });
+
+  @override
+  State<_DrawerAwareSwipeDetector> createState() =>
+      _DrawerAwareSwipeDetectorState();
+}
+
+class _DrawerAwareSwipeDetectorState extends State<_DrawerAwareSwipeDetector> {
+  double? _startX;
+
+  @override
+  Widget build(BuildContext context) {
+    return Listener(
+      onPointerDown: (event) {
+        _startX = event.position.dx;
+      },
+      onPointerUp: (event) {
+        final startX = _startX;
+        _startX = null;
+        if (startX == null) return;
+        if (startX < 60) return;
+        final dx = event.position.dx - startX;
+        if (dx.abs() < 50) return;
+        if (dx < 0) {
+          widget.onSwipeLeft();
+        } else {
+          widget.onSwipeRight();
+        }
+      },
+      child: widget.child,
     );
   }
 }

--- a/lib/homepage.dart
+++ b/lib/homepage.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:how_many_mobile_meeple/components/board_game_item_input_widget.dart';
 import 'package:how_many_mobile_meeple/components/board_game_item_list_widget.dart';
 import 'package:how_many_mobile_meeple/components/complexity_filter_widget.dart';
+import 'package:how_many_mobile_meeple/components/feature_drawer.dart';
 import 'package:how_many_mobile_meeple/components/mechanic_filter_widget.dart';
 import 'package:how_many_mobile_meeple/components/player_filter_widget.dart';
 import 'package:how_many_mobile_meeple/components/rating_filter_widget.dart';
@@ -34,6 +35,8 @@ class HomePage extends StatelessWidget with AppPage {
             isHomePage: true,
             model: model,
             context: context),
+        drawer: const FeatureDrawer(),
+        drawerEdgeDragWidth: 60,
         endDrawer: pageDrawer(context),
         bottomNavigationBar: Container(
           color: Theme.of(context).highlightColor,

--- a/lib/how_many_meeple_app_bar.dart
+++ b/lib/how_many_meeple_app_bar.dart
@@ -1,8 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:url_launcher/url_launcher.dart';
 
 import 'app_common.dart';
-import 'components/quick_pick_sheet.dart';
 import 'model/model.dart';
 import 'platform/router.dart' as r;
 import 'save_dialog.dart';
@@ -17,19 +15,37 @@ class HowManyMeepleAppBar extends AppBar {
       : super(
           backgroundColor: Theme.of(context).colorScheme.primary,
           foregroundColor: Theme.of(context).colorScheme.onPrimary,
-          leading: isHomePage
-              ? null
-              : IconButton(
-                  icon: const Icon(Icons.arrow_back),
-                  tooltip: 'Back',
-                  onPressed: () {
-                    if (Navigator.of(context).canPop()) {
-                      Navigator.of(context).pop();
-                    } else {
-                      Navigator.of(context).pushNamedAndRemoveUntil(
-                          r.Router.homeRoute, (route) => false);
-                    }
-                  }),
+          leading: Builder(
+            builder: (ctx) => isHomePage
+                ? IconButton(
+                    icon: const Icon(Icons.menu),
+                    tooltip: 'Menu',
+                    onPressed: () => Scaffold.of(ctx).openDrawer(),
+                  )
+                : Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      IconButton(
+                        icon: const Icon(Icons.menu),
+                        tooltip: 'Menu',
+                        onPressed: () => Scaffold.of(ctx).openDrawer(),
+                      ),
+                      IconButton(
+                        icon: const Icon(Icons.arrow_back),
+                        tooltip: 'Back',
+                        onPressed: () {
+                          if (Navigator.of(ctx).canPop()) {
+                            Navigator.of(ctx).pop();
+                          } else {
+                            Navigator.of(ctx).pushNamedAndRemoveUntil(
+                                r.Router.homeRoute, (route) => false);
+                          }
+                        },
+                      ),
+                    ],
+                  ),
+          ),
+          leadingWidth: isHomePage ? null : 96,
           titleSpacing: isHomePage ? null : 0,
           title: Column(
             mainAxisAlignment: MainAxisAlignment.center,
@@ -52,23 +68,6 @@ class HowManyMeepleAppBar extends AppBar {
                   : null,
               mainAxisSize: MainAxisSize.min,
               children: [
-                IconButton(
-                  icon: const Icon(Icons.newspaper, size: 20),
-                  tooltip: 'Board Game News',
-                  visualDensity: VisualDensity.compact,
-                  onPressed: () => launchUrl(
-                    Uri.parse('https://www.boardgamenews.co.uk/'),
-                    mode: LaunchMode.externalApplication,
-                  ),
-                ),
-                Builder(
-                  builder: (ctx) => IconButton(
-                    icon: const Icon(Icons.bolt, size: 20),
-                    tooltip: 'Quick Pick',
-                    visualDensity: VisualDensity.compact,
-                    onPressed: () => QuickPickSheet.show(ctx),
-                  ),
-                ),
                 Builder(
                   builder: (ctx) => IconButton(
                     icon: const Icon(Icons.favorite, size: 20),

--- a/lib/load_games.dart
+++ b/lib/load_games.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'package:http/http.dart' as http;
 
+import 'api/http_retry_client.dart';
 import 'app_common.dart';
 import 'package:how_many_mobile_meeple/model/game_request.dart';
 import 'package:how_many_mobile_meeple/model/item.dart';
@@ -8,15 +9,11 @@ import 'model/game.dart';
 import 'model/games.dart';
 
 class LoadGames {
-  static const int _initialBackoffSeconds = 2;
-  static const int _maxBackoffSeconds = 30;
-  static const Duration _retryTimeout = Duration(seconds: 600);
-
   static Future<Games> fetchGames(GameRequest request) async {
     Games games = Games(gamesByName: Map<String, Game>());
 
-    final futures = request.items.itemList
-        .map((item) => _fetchWithRetry(item, request.headers));
+    final futures =
+        request.items.itemList.map((item) => _fetchItem(item, request.headers));
     final responses = await Future.wait(futures);
 
     for (var response in responses) {
@@ -27,30 +24,20 @@ class LoadGames {
     return games;
   }
 
-  static Future<http.Response> _fetchWithRetry(
+  static Future<http.Response> _fetchItem(
       Item item, Map<String, String> headers) async {
     final url = item.itemType == ItemType.hotList
         ? Uri.parse("${AppCommon.boardGameGeekProxyUrl}/hot")
         : Uri.parse(
             "${AppCommon.boardGameGeekProxyUrl}/${item.itemType.name}/${Uri.encodeComponent(item.name)}");
-    final deadline = DateTime.now().add(_retryTimeout);
-    int backoff = _initialBackoffSeconds;
 
-    while (true) {
-      final response = await http.get(url, headers: headers);
+    final response = await HttpRetryClient.getWithRetry(url, headers: headers);
 
-      if (response.statusCode == 200) return response;
+    if (response.statusCode == 200) return response;
 
-      if (response.statusCode == 202 && DateTime.now().isBefore(deadline)) {
-        await Future.delayed(Duration(seconds: backoff));
-        backoff = (backoff * 2).clamp(0, _maxBackoffSeconds);
-        continue;
-      }
-
-      final source = item.itemType == ItemType.hotList
-          ? 'trending games'
-          : '${item.itemType.name} "${item.name}"';
-      throw Exception('Failed to load $source');
-    }
+    final source = item.itemType == ItemType.hotList
+        ? 'trending games'
+        : '${item.itemType.name} "${item.name}"';
+    throw Exception('Failed to load $source');
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -49,6 +49,21 @@ class MyApp extends StatelessWidget {
               onPrimary: Colors.white, // White text on primary color buttons
             ),
             highlightColor: _swatch.shade50,
+            switchTheme: SwitchThemeData(
+              thumbColor: WidgetStateProperty.resolveWith(
+                (states) => states.contains(WidgetState.selected)
+                    ? Colors.white
+                    : _swatch.shade600,
+              ),
+              trackColor: WidgetStateProperty.resolveWith(
+                (states) => states.contains(WidgetState.selected)
+                    ? _swatch.shade600
+                    : Colors.white,
+              ),
+              trackOutlineColor: WidgetStateProperty.resolveWith(
+                (states) => _swatch.shade600,
+              ),
+            ),
             filledButtonTheme: FilledButtonThemeData(
               style: FilledButton.styleFrom(
                 foregroundColor: Colors.white, // White text/icons

--- a/lib/model/game.dart
+++ b/lib/model/game.dart
@@ -1,4 +1,4 @@
-enum SortableGameField { name, maxPlaytime, rating, weight }
+enum SortableGameField { name, maxPlaytime, rating, weight, plays }
 
 class Game {
   final int id;

--- a/lib/model/model.dart
+++ b/lib/model/model.dart
@@ -1,10 +1,15 @@
+import 'dart:convert';
 import 'package:flutter/cupertino.dart';
+import 'package:how_many_mobile_meeple/api/http_retry_client.dart';
+import 'package:how_many_mobile_meeple/api/plays_service.dart';
+import 'package:how_many_mobile_meeple/model/play_data.dart';
 import 'package:how_many_mobile_meeple/platform/web/url_fragment_extractor.dart';
 import 'package:how_many_mobile_meeple/storage/preferences_history_interface.dart';
 import 'package:how_many_mobile_meeple/storage/storage_factory.dart';
 import 'package:how_many_mobile_meeple/storage/stored_preferences.dart';
 import 'package:provider/provider.dart';
 import 'package:how_many_mobile_meeple/model/settings.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:how_many_mobile_meeple/model/app_preferences.dart';
 import 'package:how_many_mobile_meeple/model/bgg_cache.dart';
@@ -37,6 +42,11 @@ class AppModel extends ChangeNotifier {
   StoredPreferences? _store;
   List<AppPreferences>? _cachedPreferences;
 
+  String? _primaryPlayer;
+  Map<int, PlayData> _playsData = {};
+  bool _playsLoaded = false;
+  Set<int> _collectionGameIds = {};
+
   late Settings _settings;
   Orientation? screenOrientation;
 
@@ -45,6 +55,67 @@ class AppModel extends ChangeNotifier {
   BggCache get bggCache => _bggCache;
 
   Settings get settings => _settings;
+
+  String? get primaryPlayer => _primaryPlayer;
+
+  set primaryPlayer(String? value) {
+    if (_primaryPlayer == value) return;
+    _primaryPlayer = value;
+    _playsLoaded = false;
+    _playsData = {};
+    _collectionGameIds = {};
+    _persistPrimaryPlayer();
+    notifyListeners();
+    if (value != null) {
+      loadPlays();
+    }
+  }
+
+  Map<int, PlayData> get playsData => _playsData;
+
+  bool get playsLoaded => _playsLoaded;
+
+  int getPlayCount(int gameId) => _playsData[gameId]?.totalPlays ?? 0;
+
+  bool isUnplayed(int gameId) => getPlayCount(gameId) == 0;
+
+  bool isInCollection(int gameId) => _collectionGameIds.contains(gameId);
+
+  Future<void> loadPlays() async {
+    if (_primaryPlayer == null) return;
+    final results = await Future.wait([
+      PlaysService.fetchPlays(_primaryPlayer!),
+      _fetchCollectionIds(_primaryPlayer!),
+    ]);
+    _playsData = results[0] as Map<int, PlayData>;
+    _collectionGameIds = results[1] as Set<int>;
+    _playsLoaded = true;
+    notifyListeners();
+  }
+
+  Future<Set<int>> _fetchCollectionIds(String username) async {
+    final url = Uri.parse(
+        '${AppCommon.boardGameGeekProxyUrl}/collection/${Uri.encodeComponent(username)}');
+    final headers = {
+      Settings.fieldsToReturnFromApi.header!:
+          Settings.fieldsToReturnFromApi.value.toString(),
+    };
+    final response = await HttpRetryClient.getWithRetry(url, headers: headers);
+    if (response.statusCode == 200) {
+      final List<dynamic> jsonList = jsonDecode(response.body);
+      return jsonList.map<int>((g) => g['id'] as int).toSet();
+    }
+    return {};
+  }
+
+  Future<void> _persistPrimaryPlayer() async {
+    final prefs = await SharedPreferences.getInstance();
+    if (_primaryPlayer != null) {
+      await prefs.setString('primary_player', _primaryPlayer!);
+    } else {
+      await prefs.remove('primary_player');
+    }
+  }
 
   SortOrder sortDirection = SortOrder.Desc;
 
@@ -86,6 +157,10 @@ class AppModel extends ChangeNotifier {
 
   Future<void> addItem(Item item) async {
     _items.itemList.add(item);
+    if (item.itemType == ItemType.collection && _primaryPlayer == null) {
+      _primaryPlayer = item.name;
+      _persistPrimaryPlayer();
+    }
     invalidateCache();
     await updateStore();
   }
@@ -129,6 +204,14 @@ class AppModel extends ChangeNotifier {
 
   Future<void> deleteItem(Item item) async {
     _items.itemList.remove(item);
+    if (item.itemType == ItemType.collection && _primaryPlayer == item.name) {
+      final nextCollection = _items.itemList
+          .where((i) => i.itemType == ItemType.collection)
+          .toList();
+      _primaryPlayer =
+          nextCollection.isNotEmpty ? nextCollection.first.name : null;
+      _persistPrimaryPlayer();
+    }
     invalidateCache();
     await _storeItems(_items);
   }
@@ -162,13 +245,20 @@ class AppModel extends ChangeNotifier {
     if (_extractor.containsModel()) {
       hasLoadedPersistedData = true;
       _urlConsumed = true;
-      return;
+    } else {
+      final store = await _getStore();
+      _items = await store.loadItems(AppCommon.maxItemsFromBgg);
+      replaceSettings(await store.loadSettings(settings));
+      hasLoadedPersistedData = true;
     }
-    final store = await _getStore();
-    _items = await store.loadItems(AppCommon.maxItemsFromBgg);
-    replaceSettings(await store.loadSettings(settings));
-    hasLoadedPersistedData = true;
+
+    final prefs = await SharedPreferences.getInstance();
+    _primaryPlayer = prefs.getString('primary_player');
     notifyListeners();
+
+    if (_primaryPlayer != null) {
+      loadPlays();
+    }
     for (final item in _items.itemList) {
       if (item.itemType == ItemType.hotList) continue;
       PrefetchService.warmCache(item);

--- a/lib/model/play_data.dart
+++ b/lib/model/play_data.dart
@@ -1,0 +1,30 @@
+class PlayData {
+  final int gameId;
+  final String gameName;
+  final int totalPlays;
+
+  PlayData({
+    required this.gameId,
+    required this.gameName,
+    required this.totalPlays,
+  });
+
+  factory PlayData.fromJson(Map<String, dynamic> json) => PlayData(
+        gameId: json['game_id'],
+        gameName: json['game_name'],
+        totalPlays: json['total_plays'] ?? 0,
+      );
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is PlayData &&
+          runtimeType == other.runtimeType &&
+          gameId == other.gameId;
+
+  @override
+  int get hashCode => gameId.hashCode;
+
+  @override
+  String toString() => '$gameName (id: $gameId, plays: $totalPlays)';
+}

--- a/lib/model/settings.dart
+++ b/lib/model/settings.dart
@@ -36,6 +36,9 @@ class Settings {
   static Setting filterMinRating =
       Setting("minimumRating", header: "Bgg-Filter-Min-Rating", value: 5.0);
 
+  static Setting filterShelfOfShameOnly =
+      Setting("shelfOfShameOnly", value: false, enabled: false);
+
   static Setting preferAdvancedMode =
       Setting("preferAdvancedMode", value: false, enabled: true);
 
@@ -57,6 +60,8 @@ class Settings {
             Settings.filterUseAllMechanics.clone(),
         Settings.filterComplexity.name: Settings.filterComplexity.clone(),
         Settings.filterMinRating.name: Settings.filterMinRating.clone(),
+        Settings.filterShelfOfShameOnly.name:
+            Settings.filterShelfOfShameOnly.clone(),
         Settings.preferAdvancedMode.name: Settings.preferAdvancedMode.clone(),
       }));
 

--- a/lib/platform/common/game_detail_page.dart
+++ b/lib/platform/common/game_detail_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:how_many_mobile_meeple/api/game_detail_service.dart';
 import 'package:how_many_mobile_meeple/components/app_default_padding.dart';
+import 'package:how_many_mobile_meeple/components/feature_drawer.dart';
 import 'package:how_many_mobile_meeple/components/game_image_with_stats.dart';
 import 'package:how_many_mobile_meeple/components/recommendations_widget.dart';
 import 'package:how_many_mobile_meeple/favourites/game_action_buttons.dart';
@@ -34,6 +35,7 @@ class _GameDetailPageState extends State<GameDetailPage>
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: HowManyMeepleAppBar('Game Details', context: context),
+      drawer: const FeatureDrawer(),
       endDrawer: pageDrawer(context),
       persistentFooterButtons: [iconButtonGroup(context)],
       body: FutureBuilder<Game>(

--- a/lib/platform/router.dart
+++ b/lib/platform/router.dart
@@ -8,6 +8,7 @@ import 'package:how_many_mobile_meeple/platform/common/game_detail_page.dart';
 import 'package:how_many_mobile_meeple/platform/pages.dart';
 import 'package:how_many_mobile_meeple/platform/web/url_fragment_encoder.dart';
 import 'package:how_many_mobile_meeple/settings_summary_page.dart';
+import 'package:how_many_mobile_meeple/shelf_of_shame/shelf_of_shame_page.dart';
 
 class Router {
   static const String homeRoute = '/';
@@ -18,10 +19,12 @@ class Router {
   static const String favouritesRoute = '/favourites';
   static const String ignoredRoute = '/ignored';
   static const String aboutRoute = '/about';
+  static const String shelfOfShameRoute = '/shelf-of-shame';
 
   static List<String> routeList = [
     randomRoute,
     listRoute,
+    shelfOfShameRoute,
     settingsRoute,
     homeRoute
   ];
@@ -80,6 +83,15 @@ class Router {
                       'Swipe left on a game in the list to hide it from future results.',
                   serviceFactory: IgnoredGamesService.instance,
                 ),
+            settings: settings);
+      case Router.shelfOfShameRoute:
+        final sosSegments =
+            settings.name!.split('/').where((s) => s.isNotEmpty).toList();
+        final sosUsername = sosSegments.length > 1
+            ? Uri.decodeComponent(sosSegments.last)
+            : null;
+        return MaterialPageRoute(
+            builder: (_) => ShelfOfShamePage(username: sosUsername),
             settings: settings);
       case Router.aboutRoute:
         return MaterialPageRoute(

--- a/lib/platform/web_or_tablet/enhanced_list_games_display.dart
+++ b/lib/platform/web_or_tablet/enhanced_list_games_display.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:how_many_mobile_meeple/components/app_default_padding.dart';
+import 'package:how_many_mobile_meeple/components/feature_drawer.dart';
 import 'package:how_many_mobile_meeple/favourites/favourite_game.dart';
 import 'package:how_many_mobile_meeple/favourites/favourites_service.dart';
 import 'package:how_many_mobile_meeple/favourites/ignored_games_service.dart';
@@ -15,6 +16,8 @@ import '../../network_content_widget.dart';
 import '../../screen_tools.dart';
 import 'package:how_many_mobile_meeple/components/platform_independent_image.dart';
 import 'package:how_many_mobile_meeple/components/rating_badge.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+import 'package:how_many_mobile_meeple/model/settings.dart';
 
 class EnhancedListGamesDisplayPage extends NetworkWidget with AppPage {
   @override
@@ -22,6 +25,7 @@ class EnhancedListGamesDisplayPage extends NetworkWidget with AppPage {
     return Scaffold(
         appBar:
             HowManyMeepleAppBar(AppCommon.listGamesPageTitle, context: context),
+        drawer: const FeatureDrawer(),
         endDrawer: pageDrawer(context),
         persistentFooterButtons: [iconButtonGroup(context)],
         body: Container(child: loadNetworkContent(displayGame)));
@@ -85,14 +89,34 @@ class _GameListBodyState extends State<_GameListBody> with ScreenTools {
     if (mounted) setState(() {});
   }
 
+  List<Game> _sortByPlays(AppModel model) {
+    final games = model.bggCache.games.getGamesByName(SortOrder.Asc);
+    games.sort((a, b) {
+      final aPlays = model.getPlayCount(a.id);
+      final bPlays = model.getPlayCount(b.id);
+      return model.sortDirection == SortOrder.Asc
+          ? aPlays.compareTo(bPlays)
+          : bPlays.compareTo(aPlays);
+    });
+    return games;
+  }
+
   @override
   Widget build(BuildContext context) {
     final model = widget.model;
-    var allGames = model.bggCache.games
-        .getGamesBy(field: model.sortGameField, order: model.sortDirection);
-    final games = _showIgnored
+    var allGames = model.sortGameField == SortableGameField.plays
+        ? _sortByPlays(model)
+        : model.bggCache.games
+            .getGamesBy(field: model.sortGameField, order: model.sortDirection);
+    var games = _showIgnored
         ? allGames
         : allGames.where((g) => !widget.ignoredService.contains(g.id)).toList();
+
+    final sosSetting =
+        model.settings.setting(Settings.filterShelfOfShameOnly.name);
+    if (sosSetting.enabled && sosSetting.getBool() && model.playsLoaded) {
+      games = games.where((g) => model.isUnplayed(g.id)).toList();
+    }
 
     if (games.isEmpty) {
       return _buildExhaustedState(context);
@@ -150,6 +174,7 @@ class _GameListBodyState extends State<_GameListBody> with ScreenTools {
   }
 
   Widget _buildHeader(BuildContext context, AppModel model) {
+    final isWide = isWideScreen(context);
     return Container(
       decoration: BoxDecoration(
         border:
@@ -157,28 +182,37 @@ class _GameListBodyState extends State<_GameListBody> with ScreenTools {
       ),
       child: Row(
         children: [
-          const SizedBox(width: 56),
+          const SizedBox(width: 52),
           Expanded(
-            flex: 4,
             child: _sortButton(context, model, 'Name', SortableGameField.name,
                 alignment: Alignment.centerLeft),
           ),
+          if (isWide) ...[
+            SizedBox(
+              width: 80,
+              child: _sortButton(
+                  context, model, null, SortableGameField.maxPlaytime,
+                  icon: Icons.timer),
+            ),
+            SizedBox(
+              width: 60,
+              child: _sortButton(context, model, null, SortableGameField.weight,
+                  icon: Icons.fitness_center),
+            ),
+            if (model.playsLoaded)
+              SizedBox(
+                width: 60,
+                child: _sortButton(
+                    context, model, null, SortableGameField.plays,
+                    icon: Icons.sports_esports),
+              ),
+          ],
           SizedBox(
-            width: 80,
-            child: _sortButton(
-                context, model, null, SortableGameField.maxPlaytime,
-                icon: Icons.timer),
-          ),
-          SizedBox(
-            width: 60,
-            child: _sortButton(context, model, null, SortableGameField.weight,
-                icon: Icons.fitness_center),
-          ),
-          SizedBox(
-            width: 60,
+            width: isWide ? 60 : 50,
             child: _sortButton(context, model, null, SortableGameField.rating,
                 icon: Icons.star),
           ),
+          if (isWide) const SizedBox(width: 80),
         ],
       ),
     );
@@ -310,7 +344,6 @@ class _GameListBodyState extends State<_GameListBody> with ScreenTools {
             ),
           ),
           Expanded(
-            flex: 4,
             child: AppDefaultPadding(
               child: InkWell(
                 onTap: () => Navigator.of(context).pushNamed(
@@ -319,38 +352,58 @@ class _GameListBodyState extends State<_GameListBody> with ScreenTools {
                   crossAxisAlignment: CrossAxisAlignment.start,
                   mainAxisSize: MainAxisSize.min,
                   children: [
-                    Row(
-                      children: [
-                        if (isFav)
-                          Padding(
-                            padding: const EdgeInsets.only(right: 4),
-                            child: Icon(Icons.favorite,
-                                size: 14, color: Colors.amber.shade700),
-                          ),
-                        Flexible(
-                          child: Text(game.name,
-                              style: const TextStyle(
-                                decoration: TextDecoration.underline,
-                              )),
-                        ),
-                      ],
-                    ),
+                    Text(game.name,
+                        overflow: TextOverflow.ellipsis,
+                        style: const TextStyle(
+                          decoration: TextDecoration.underline,
+                        )),
                     const SizedBox(height: 2),
                     Row(
-                      mainAxisSize: MainAxisSize.min,
                       children: [
+                        if (isFav) ...[
+                          Icon(Icons.favorite,
+                              size: 12, color: Colors.amber.shade700),
+                          const SizedBox(width: 6),
+                        ],
                         Icon(Icons.people,
                             size: 12,
                             color: Theme.of(context).colorScheme.secondary),
                         const SizedBox(width: 3),
                         Text(
                           game.minPlayers == game.maxPlayers
-                              ? '${game.minPlayers} players'
-                              : '${game.minPlayers}-${game.maxPlayers} players',
+                              ? '${game.minPlayers}p'
+                              : '${game.minPlayers}-${game.maxPlayers}p',
                           style: TextStyle(
                               fontSize: 11,
                               color: Theme.of(context).colorScheme.secondary),
                         ),
+                        if (widget.model.primaryPlayer != null &&
+                            widget.model.isInCollection(game.id)) ...[
+                          const SizedBox(width: 6),
+                          FaIcon(FontAwesomeIcons.crown,
+                              size: 10,
+                              color: Theme.of(context)
+                                  .colorScheme
+                                  .secondary
+                                  .withAlpha(150)),
+                        ],
+                        if (widget.model.playsLoaded) ...[
+                          const SizedBox(width: 6),
+                          Text(
+                            widget.model.getPlayCount(game.id) > 0
+                                ? '${widget.model.getPlayCount(game.id)} plays'
+                                : 'Unplayed',
+                            style: TextStyle(
+                              fontSize: 10,
+                              color: widget.model.getPlayCount(game.id) > 0
+                                  ? Theme.of(context).colorScheme.secondary
+                                  : Theme.of(context)
+                                      .colorScheme
+                                      .error
+                                      .withAlpha(180),
+                            ),
+                          ),
+                        ],
                       ],
                     ),
                   ],
@@ -358,28 +411,48 @@ class _GameListBodyState extends State<_GameListBody> with ScreenTools {
               ),
             ),
           ),
-          SizedBox(
-            width: 80,
-            child: AppDefaultPadding(
-              child: Container(
-                alignment: Alignment.centerRight,
-                child: Text(AppCommon.minutesToTime(game.maxPlaytime)),
+          if (isWide) ...[
+            SizedBox(
+              width: 80,
+              child: AppDefaultPadding(
+                child: Container(
+                  alignment: Alignment.centerRight,
+                  child: Text(AppCommon.minutesToTime(game.maxPlaytime)),
+                ),
               ),
             ),
-          ),
-          SizedBox(
-            width: 60,
-            child: AppDefaultPadding(
-              child: Container(
-                alignment: Alignment.centerRight,
-                child: Text(game.averageWeight.toStringAsFixed(2)),
+            SizedBox(
+              width: 60,
+              child: AppDefaultPadding(
+                child: Container(
+                  alignment: Alignment.centerRight,
+                  child: Text(game.averageWeight.toStringAsFixed(2)),
+                ),
               ),
             ),
-          ),
+            if (widget.model.playsLoaded)
+              SizedBox(
+                width: 60,
+                child: AppDefaultPadding(
+                  child: Container(
+                    alignment: Alignment.centerRight,
+                    child: Text(
+                      '${widget.model.getPlayCount(game.id)}',
+                      style: TextStyle(
+                        color: widget.model.getPlayCount(game.id) == 0
+                            ? Theme.of(context).colorScheme.error.withAlpha(180)
+                            : null,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+          ],
           SizedBox(
-            width: 60,
+            width: isWide ? 60 : 50,
             child: Center(
-              child: MiniRatingBadge(rating: game.averageRating, size: 38),
+              child: MiniRatingBadge(
+                  rating: game.averageRating, size: isWide ? 38 : 34),
             ),
           ),
           if (isWide) ...[

--- a/lib/platform/web_or_tablet/web_random_game_display.dart
+++ b/lib/platform/web_or_tablet/web_random_game_display.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
+import 'package:how_many_mobile_meeple/components/feature_drawer.dart';
 import 'package:how_many_mobile_meeple/components/game_image_with_stats.dart';
 import 'package:how_many_mobile_meeple/components/recommendations_widget.dart';
 import 'package:how_many_mobile_meeple/favourites/game_action_buttons.dart';
 import 'package:how_many_mobile_meeple/favourites/ignored_games_service.dart';
 import 'package:how_many_mobile_meeple/platform/common/game_display_page.dart';
+import 'package:how_many_mobile_meeple/model/settings.dart';
 import 'package:how_many_mobile_meeple/platform/router.dart' as r;
 import 'package:how_many_mobile_meeple/screen_tools.dart';
 
@@ -19,6 +21,7 @@ class WebRandomGameDisplayPage extends GameDisplayPage {
     return Scaffold(
         appBar: HowManyMeepleAppBar(AppCommon.randomGamePageTitle,
             context: context),
+        drawer: const FeatureDrawer(),
         endDrawer: pageDrawer(context),
         persistentFooterButtons: [iconButtonGroup(context)],
         body: Container(child: loadNetworkContent(displayGame)));
@@ -28,6 +31,16 @@ class WebRandomGameDisplayPage extends GameDisplayPage {
     var cachedGames = model.bggCache;
     Game? game =
         hasPageRefreshed(model) ? cachedGames.random : cachedGames.lastRandom;
+
+    final sosSetting =
+        model.settings.setting(Settings.filterShelfOfShameOnly.name);
+    final shelfOnly =
+        sosSetting.enabled && sosSetting.getBool() && model.playsLoaded;
+
+    if (shelfOnly && game != null && !model.isUnplayed(game.id)) {
+      game = _nextUnplayed(model);
+    }
+
     if (game == null) {
       return _buildExhaustedState(context, model);
     }
@@ -55,6 +68,15 @@ class WebRandomGameDisplayPage extends GameDisplayPage {
         ),
       ),
     );
+  }
+
+  Game? _nextUnplayed(AppModel model) {
+    for (var i = 0; i < 100; i++) {
+      final candidate = model.bggCache.random;
+      if (candidate == null) return null;
+      if (model.isUnplayed(candidate.id)) return candidate;
+    }
+    return null;
   }
 
   Widget _buildExhaustedState(BuildContext context, AppModel model) {

--- a/lib/settings_summary_page.dart
+++ b/lib/settings_summary_page.dart
@@ -4,6 +4,7 @@ import 'package:how_many_mobile_meeple/model/settings.dart';
 import 'package:how_many_mobile_meeple/how_many_meeple_app_bar.dart';
 import 'package:how_many_mobile_meeple/app_common.dart';
 import 'package:how_many_mobile_meeple/app_page.dart';
+import 'package:how_many_mobile_meeple/components/feature_drawer.dart';
 import 'package:how_many_mobile_meeple/components/disclaimer_text.dart';
 import 'package:how_many_mobile_meeple/components/empty_widget.dart';
 import 'package:package_info_plus/package_info_plus.dart';
@@ -44,6 +45,7 @@ class SettingsSummaryPage extends StatelessWidget with AppPage {
         model: model,
         context: context,
       ),
+      drawer: const FeatureDrawer(),
       endDrawer: pageDrawer(context),
       body: SingleChildScrollView(
         child: Padding(

--- a/lib/shelf_of_shame/shelf_of_shame_page.dart
+++ b/lib/shelf_of_shame/shelf_of_shame_page.dart
@@ -1,0 +1,372 @@
+import 'dart:convert';
+import 'package:flutter/material.dart';
+import 'package:flutter_spinkit/flutter_spinkit.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+import 'package:provider/provider.dart';
+import 'package:url_launcher/url_launcher.dart';
+import 'package:how_many_mobile_meeple/api/http_retry_client.dart';
+import 'package:how_many_mobile_meeple/app_common.dart';
+import 'package:how_many_mobile_meeple/app_page.dart';
+import 'package:how_many_mobile_meeple/components/feature_drawer.dart';
+import 'package:how_many_mobile_meeple/components/loading_fun_facts.dart';
+import 'package:how_many_mobile_meeple/components/platform_independent_image.dart';
+import 'package:how_many_mobile_meeple/how_many_meeple_app_bar.dart';
+import 'package:how_many_mobile_meeple/model/game.dart';
+import 'package:how_many_mobile_meeple/model/games.dart';
+import 'package:how_many_mobile_meeple/model/item.dart';
+import 'package:how_many_mobile_meeple/model/model.dart';
+import 'package:how_many_mobile_meeple/model/settings.dart';
+import 'package:how_many_mobile_meeple/network_content_widget.dart';
+import 'package:how_many_mobile_meeple/platform/router.dart' as r;
+import 'package:how_many_mobile_meeple/screen_tools.dart';
+
+class ShelfOfShamePage extends StatefulWidget {
+  final String? username;
+
+  const ShelfOfShamePage({super.key, this.username});
+
+  @override
+  State<ShelfOfShamePage> createState() => _ShelfOfShamePageState();
+}
+
+class _ShelfOfShamePageState extends State<ShelfOfShamePage>
+    with AppPage, ScreenTools {
+  Games? _fullCollection;
+  bool _loading = true;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadData();
+  }
+
+  String? get _targetUsername {
+    return widget.username ?? AppModel.of(context, listen: false).primaryPlayer;
+  }
+
+  Future<void> _loadData() async {
+    final model = AppModel.of(context, listen: false);
+    final username = _targetUsername;
+    if (username == null) {
+      setState(() => _loading = false);
+      return;
+    }
+
+    try {
+      if (!model.playsLoaded) {
+        await model.loadPlays();
+      }
+      final games = await _fetchFullCollection(username);
+      if (mounted) {
+        setState(() {
+          _fullCollection = games;
+          _loading = false;
+        });
+      }
+    } catch (e) {
+      if (mounted) {
+        setState(() {
+          _error = 'Failed to load collection';
+          _loading = false;
+        });
+      }
+    }
+  }
+
+  Future<Games> _fetchFullCollection(String username) async {
+    final url = Uri.parse(
+        '${AppCommon.boardGameGeekProxyUrl}/collection/${Uri.encodeComponent(username)}');
+    final headers = {
+      Settings.fieldsToReturnFromApi.header!:
+          Settings.fieldsToReturnFromApi.value.toString(),
+    };
+    final response = await HttpRetryClient.getWithRetry(url, headers: headers);
+    if (response.statusCode == 200) {
+      return Games.fromJson(jsonDecode(response.body));
+    }
+    throw Exception('Failed to load collection');
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: HowManyMeepleAppBar('Shelf of Shame', context: context),
+      drawer: const FeatureDrawer(),
+      endDrawer: pageDrawer(context),
+      body: Consumer<AppModel>(
+        builder: (context, model, child) {
+          final hasCollection = model.items.itemList
+              .any((item) => item.itemType == ItemType.collection);
+          if (!hasCollection && widget.username == null) {
+            return _buildNoCollection(context);
+          }
+          if (_targetUsername == null) {
+            return _buildNoPrimaryPlayer(context);
+          }
+          if (_loading) {
+            return _buildLoadingScreen(context);
+          }
+          if (_error != null) {
+            return Center(child: Text(_error!));
+          }
+          return _buildBody(context, model);
+        },
+      ),
+    );
+  }
+
+  Widget _buildNoCollection(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.shelves,
+                size: 64, color: Theme.of(context).colorScheme.secondary),
+            const SizedBox(height: 16),
+            Text(
+              'No collection added',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Shelf of Shame requires a BGG collection. Add your BGG username in Step 1 to get started.',
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    color: Theme.of(context).colorScheme.onSurfaceVariant,
+                  ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildNoPrimaryPlayer(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.shelves,
+                size: 64, color: Theme.of(context).colorScheme.secondary),
+            const SizedBox(height: 16),
+            Text(
+              'No primary player set',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Add a BGG collection in Step 1 and tap the crown icon to designate your primary player for play tracking.',
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    color: Theme.of(context).colorScheme.onSurfaceVariant,
+                  ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildLoadingScreen(BuildContext context) {
+    final spinnerSize = getScreenWidthPercentageInPixels(
+            context, ScreenTools.fiftyPercentScreen)
+        .clamp(0.0, 200.0);
+
+    return Center(
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 480),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            SpinKitCubeGrid(
+              size: spinnerSize,
+              itemBuilder: (context, index) {
+                final isLight = (index ~/ 3 + index % 3) % 2 == 0;
+                final color = Theme.of(context).colorScheme.secondary;
+                return DecoratedBox(
+                  decoration: BoxDecoration(
+                    color: isLight ? color : color.withValues(alpha: 0.5),
+                  ),
+                );
+              },
+            ),
+            const SizedBox(height: 16),
+            Text(NetworkWidget.findingGames,
+                style: const TextStyle(fontWeight: FontWeight.bold)),
+            Text(
+              NetworkWidget.speedDisclaimer,
+              style: const TextStyle(fontSize: 12),
+            ),
+            const SizedBox(height: 16),
+            const LoadingFunFacts(),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildBody(BuildContext context, AppModel model) {
+    final allGames = _fullCollection!;
+    final unplayedGames = allGames.gamesByName.values
+        .where((game) => model.isUnplayed(game.id))
+        .toList();
+
+    if (unplayedGames.isEmpty) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.all(32),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(Icons.celebration,
+                  size: 64, color: Theme.of(context).colorScheme.secondary),
+              const SizedBox(height: 16),
+              Text(
+                'No shame here!',
+                style: Theme.of(context).textTheme.titleMedium,
+              ),
+              const SizedBox(height: 8),
+              Text(
+                'All your games have been played at least once. Well done!',
+                textAlign: TextAlign.center,
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                      color: Theme.of(context).colorScheme.onSurfaceVariant,
+                    ),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    return Column(
+      children: [
+        _buildCollectionBanner(context, model, unplayedGames.length),
+        Expanded(
+          child: ListView.builder(
+            itemCount: unplayedGames.length + 1,
+            itemBuilder: (context, index) {
+              if (index == unplayedGames.length) {
+                return _buildBgStatsPlug(context);
+              }
+              return _buildGameTile(context, unplayedGames[index], index);
+            },
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildCollectionBanner(
+      BuildContext context, AppModel model, int count) {
+    final displayName = _targetUsername ?? model.primaryPlayer ?? '';
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      color: Theme.of(context).colorScheme.primaryContainer.withAlpha(120),
+      child: Row(
+        children: [
+          FaIcon(FontAwesomeIcons.crown,
+              size: 14, color: Theme.of(context).colorScheme.primary),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              '$displayName\'s collection • $count unplayed',
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    fontWeight: FontWeight.w500,
+                    color: Theme.of(context).colorScheme.onPrimaryContainer,
+                  ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildGameTile(BuildContext context, Game game, int index) {
+    final isEven = index % 2 == 0;
+    return Material(
+      color: isEven
+          ? Colors.transparent
+          : Theme.of(context).colorScheme.primary.withAlpha(8),
+      child: ListTile(
+        leading: ClipRRect(
+          borderRadius: BorderRadius.circular(4),
+          child: SizedBox(
+            width: 44,
+            height: 44,
+            child: game.thumbnail != null
+                ? PlatformIndependentImage(
+                    imageUrl: game.thumbnail!,
+                    fit: BoxFit.cover,
+                  )
+                : Container(
+                    color: Theme.of(context).colorScheme.primaryContainer,
+                    child: Icon(Icons.casino,
+                        size: 22,
+                        color:
+                            Theme.of(context).colorScheme.onPrimaryContainer),
+                  ),
+          ),
+        ),
+        title: Text(game.name),
+        subtitle: Text(
+          '${game.minPlayers}-${game.maxPlayers} players',
+          style: TextStyle(
+              fontSize: 12, color: Theme.of(context).colorScheme.secondary),
+        ),
+        onTap: () => Navigator.of(context).pushNamed(
+            '${r.Router.gameDetailRoute}/${game.name.replaceAll(' ', '+')}/${game.id}'),
+      ),
+    );
+  }
+
+  Widget _buildBgStatsPlug(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: Card(
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Row(
+            children: [
+              Icon(Icons.bar_chart,
+                  size: 24, color: Theme.of(context).colorScheme.primary),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'Track your plays',
+                      style: Theme.of(context).textTheme.titleSmall,
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      'Log plays with BG Stats to keep your shelf of shame up to date',
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                            color:
+                                Theme.of(context).colorScheme.onSurfaceVariant,
+                          ),
+                    ),
+                  ],
+                ),
+              ),
+              IconButton(
+                icon: const Icon(Icons.open_in_new),
+                onPressed: () => launchUrl(
+                  Uri.parse('https://www.bgstatsapp.com/'),
+                  mode: LaunchMode.externalApplication,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/tour_tips/tour_tip_definitions.dart
+++ b/lib/tour_tips/tour_tip_definitions.dart
@@ -12,8 +12,7 @@ class TourTipDefinitions {
     TourTip(
       id: 'appbar_actions',
       title: 'Your Top Bar',
-      description: '📰 News: latest board game news\n'
-          '⚡ Quick Pick: skip steps, pick a random game fast\n'
+      description: '☰ Menu: quick pick, random game, shelf of shame & more\n'
           '❤️ Favourites: your saved games\n'
           '⚙️ Settings: advanced options and filters',
       pageId: pageAppBar,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,6 +27,7 @@ dependencies:
   path: ^1.9.0
   synchronized: ^3.3.0+3
   tutorial_coach_mark: ^1.3.3
+  font_awesome_flutter: ^11.0.0
 
 dev_dependencies:
   flutter_test:

--- a/test/api/http_retry_client_test.dart
+++ b/test/api/http_retry_client_test.dart
@@ -1,0 +1,123 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart' as http_testing;
+import 'package:how_many_mobile_meeple/api/http_retry_client.dart';
+
+void main() {
+  setUp(() {
+    HttpRetryClient.setDelayFunction((_) async {});
+  });
+
+  tearDown(() {
+    HttpRetryClient.resetTestClient();
+    HttpRetryClient.resetDelayFunction();
+  });
+
+  group('HttpRetryClient.getWithRetry', () {
+    test('returns response immediately on 200', () async {
+      int callCount = 0;
+      HttpRetryClient.setTestClient(
+        http_testing.MockClient((request) async {
+          callCount++;
+          return http.Response('{"data": "ok"}', 200);
+        }),
+      );
+
+      final response =
+          await HttpRetryClient.getWithRetry(Uri.parse('http://test.com/api'));
+
+      expect(response.statusCode, 200);
+      expect(response.body, '{"data": "ok"}');
+      expect(callCount, 1);
+    });
+
+    test('returns response immediately on 404', () async {
+      int callCount = 0;
+      HttpRetryClient.setTestClient(
+        http_testing.MockClient((request) async {
+          callCount++;
+          return http.Response('not found', 404);
+        }),
+      );
+
+      final response =
+          await HttpRetryClient.getWithRetry(Uri.parse('http://test.com/api'));
+
+      expect(response.statusCode, 404);
+      expect(callCount, 1);
+    });
+
+    test('retries on 202 then succeeds on 200', () async {
+      int callCount = 0;
+      HttpRetryClient.setTestClient(
+        http_testing.MockClient((request) async {
+          callCount++;
+          if (callCount < 3) {
+            return http.Response('processing', 202);
+          }
+          return http.Response('{"data": "ok"}', 200);
+        }),
+      );
+
+      final response =
+          await HttpRetryClient.getWithRetry(Uri.parse('http://test.com/api'));
+
+      expect(response.statusCode, 200);
+      expect(callCount, 3);
+    });
+
+    test('passes headers to the request', () async {
+      String? capturedHeader;
+      HttpRetryClient.setTestClient(
+        http_testing.MockClient((request) async {
+          capturedHeader = request.headers['X-Custom'];
+          return http.Response('ok', 200);
+        }),
+      );
+
+      await HttpRetryClient.getWithRetry(
+        Uri.parse('http://test.com/api'),
+        headers: {'X-Custom': 'test-value'},
+      );
+
+      expect(capturedHeader, 'test-value');
+    });
+
+    test('returns non-retryable error status immediately', () async {
+      int callCount = 0;
+      HttpRetryClient.setTestClient(
+        http_testing.MockClient((request) async {
+          callCount++;
+          return http.Response('server error', 500);
+        }),
+      );
+
+      final response =
+          await HttpRetryClient.getWithRetry(Uri.parse('http://test.com/api'));
+
+      expect(response.statusCode, 500);
+      expect(callCount, 1);
+    });
+
+    test('respects custom retryableStatuses', () async {
+      int callCount = 0;
+      HttpRetryClient.setTestClient(
+        http_testing.MockClient((request) async {
+          callCount++;
+          if (callCount < 3) {
+            return http.Response('rate limited', 429);
+          }
+          return http.Response('ok', 200);
+        }),
+      );
+
+      final response = await HttpRetryClient.getWithRetry(
+        Uri.parse('http://test.com/api'),
+        retryableStatuses: {202, 429},
+      );
+
+      expect(response.statusCode, 200);
+      expect(callCount, 3);
+    });
+  });
+}

--- a/test/api/plays_service_test.dart
+++ b/test/api/plays_service_test.dart
@@ -1,0 +1,184 @@
+import 'dart:convert';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart' as http_testing;
+import 'package:how_many_mobile_meeple/api/http_retry_client.dart';
+import 'package:how_many_mobile_meeple/api/plays_service.dart';
+
+void main() {
+  setUp(() {
+    PlaysService.clearCache();
+    HttpRetryClient.setDelayFunction((_) async {});
+  });
+
+  tearDown(() {
+    HttpRetryClient.resetTestClient();
+    HttpRetryClient.resetDelayFunction();
+    PlaysService.clearCache();
+  });
+
+  group('PlaysService.fetchPlays', () {
+    test('parses play data from API response', () async {
+      final responseBody = jsonEncode([
+        {'game_id': 1, 'game_name': 'Wingspan', 'total_plays': 5},
+        {'game_id': 2, 'game_name': 'Catan', 'total_plays': 12},
+      ]);
+
+      HttpRetryClient.setTestClient(
+        http_testing.MockClient((request) async {
+          return http.Response(responseBody, 200);
+        }),
+      );
+
+      final plays = await PlaysService.fetchPlays('testuser');
+
+      expect(plays.length, 2);
+      expect(plays[1]!.gameName, 'Wingspan');
+      expect(plays[1]!.totalPlays, 5);
+      expect(plays[2]!.gameName, 'Catan');
+      expect(plays[2]!.totalPlays, 12);
+    });
+
+    test('returns map keyed by game_id', () async {
+      final responseBody = jsonEncode([
+        {'game_id': 42, 'game_name': 'Azul', 'total_plays': 3},
+      ]);
+
+      HttpRetryClient.setTestClient(
+        http_testing.MockClient((request) async {
+          return http.Response(responseBody, 200);
+        }),
+      );
+
+      final plays = await PlaysService.fetchPlays('testuser');
+
+      expect(plays.containsKey(42), isTrue);
+      expect(plays[42]!.gameName, 'Azul');
+    });
+
+    test('returns empty map on 404', () async {
+      HttpRetryClient.setTestClient(
+        http_testing.MockClient((request) async {
+          return http.Response('not found', 404);
+        }),
+      );
+
+      final plays = await PlaysService.fetchPlays('nonexistent');
+
+      expect(plays, isEmpty);
+    });
+
+    test('throws exception on server error', () async {
+      HttpRetryClient.setTestClient(
+        http_testing.MockClient((request) async {
+          return http.Response('error', 500);
+        }),
+      );
+
+      expect(
+        () => PlaysService.fetchPlays('testuser'),
+        throwsException,
+      );
+    });
+
+    test('calls correct URL with username', () async {
+      Uri? capturedUrl;
+      HttpRetryClient.setTestClient(
+        http_testing.MockClient((request) async {
+          capturedUrl = request.url;
+          return http.Response('[]', 200);
+        }),
+      );
+
+      await PlaysService.fetchPlays('teqqles');
+
+      expect(capturedUrl!.path, '/plays/teqqles');
+    });
+
+    test('uses cached result on subsequent calls', () async {
+      int callCount = 0;
+      HttpRetryClient.setTestClient(
+        http_testing.MockClient((request) async {
+          callCount++;
+          return http.Response(
+            jsonEncode([
+              {'game_id': 1, 'game_name': 'Wingspan', 'total_plays': 5}
+            ]),
+            200,
+          );
+        }),
+      );
+
+      await PlaysService.fetchPlays('testuser');
+      await PlaysService.fetchPlays('testuser');
+
+      expect(callCount, 1);
+    });
+
+    test('caches per username separately', () async {
+      int callCount = 0;
+      HttpRetryClient.setTestClient(
+        http_testing.MockClient((request) async {
+          callCount++;
+          return http.Response('[]', 200);
+        }),
+      );
+
+      await PlaysService.fetchPlays('user1');
+      await PlaysService.fetchPlays('user2');
+
+      expect(callCount, 2);
+    });
+
+    test('retries on 202 before succeeding', () async {
+      int callCount = 0;
+      HttpRetryClient.setTestClient(
+        http_testing.MockClient((request) async {
+          callCount++;
+          if (callCount < 2) {
+            return http.Response('processing', 202);
+          }
+          return http.Response(
+            jsonEncode([
+              {'game_id': 1, 'game_name': 'Wingspan', 'total_plays': 5}
+            ]),
+            200,
+          );
+        }),
+      );
+
+      final plays = await PlaysService.fetchPlays('testuser');
+
+      expect(plays.length, 1);
+      expect(callCount, 2);
+    });
+
+    test('handles empty plays array', () async {
+      HttpRetryClient.setTestClient(
+        http_testing.MockClient((request) async {
+          return http.Response('[]', 200);
+        }),
+      );
+
+      final plays = await PlaysService.fetchPlays('newuser');
+
+      expect(plays, isEmpty);
+    });
+
+    test('clearCache forces re-fetch', () async {
+      int callCount = 0;
+      HttpRetryClient.setTestClient(
+        http_testing.MockClient((request) async {
+          callCount++;
+          return http.Response('[]', 200);
+        }),
+      );
+
+      await PlaysService.fetchPlays('testuser');
+      PlaysService.clearCache();
+      await PlaysService.fetchPlays('testuser');
+
+      expect(callCount, 2);
+    });
+  });
+}

--- a/test/components/app_bar_test.dart
+++ b/test/components/app_bar_test.dart
@@ -1,0 +1,107 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:how_many_mobile_meeple/how_many_meeple_app_bar.dart';
+import 'package:how_many_mobile_meeple/model/model.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+Widget _buildTestApp({
+  bool isHomePage = true,
+  bool hasSaveDialog = false,
+  AppModel? model,
+}) {
+  final appModel = model ?? AppModel();
+  return ChangeNotifierProvider<AppModel>.value(
+    value: appModel,
+    child: MaterialApp(
+      home: Builder(
+        builder: (context) => Scaffold(
+          appBar: HowManyMeepleAppBar(
+            'Test Subtitle',
+            context: context,
+            isHomePage: isHomePage,
+            hasSaveDialog: hasSaveDialog,
+            model: appModel,
+          ),
+          endDrawer: const Drawer(child: Text('Settings Drawer')),
+          drawer: const Drawer(child: Text('Feature Drawer')),
+          body: const Text('Body'),
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  group('HowManyMeepleAppBar', () {
+    testWidgets('does not show News button', (tester) async {
+      await tester.pumpWidget(_buildTestApp());
+
+      expect(find.byTooltip('Board Game News'), findsNothing);
+    });
+
+    testWidgets('does not show Quick Pick button', (tester) async {
+      await tester.pumpWidget(_buildTestApp());
+
+      expect(find.byTooltip('Quick Pick'), findsNothing);
+    });
+
+    testWidgets('shows Favourites button', (tester) async {
+      await tester.pumpWidget(_buildTestApp());
+
+      expect(find.byTooltip('Favourites'), findsOneWidget);
+    });
+
+    testWidgets('shows Settings button', (tester) async {
+      await tester.pumpWidget(_buildTestApp());
+
+      expect(find.byTooltip('Settings'), findsOneWidget);
+    });
+
+    testWidgets('shows Save button when hasSaveDialog is true', (tester) async {
+      await tester
+          .pumpWidget(_buildTestApp(hasSaveDialog: true, model: AppModel()));
+
+      expect(find.byTooltip('Save Settings'), findsOneWidget);
+    });
+
+    testWidgets('does not show Save button when hasSaveDialog is false',
+        (tester) async {
+      await tester.pumpWidget(_buildTestApp(hasSaveDialog: false));
+
+      expect(find.byTooltip('Save Settings'), findsNothing);
+    });
+
+    testWidgets('shows hamburger menu on home page', (tester) async {
+      await tester.pumpWidget(_buildTestApp(isHomePage: true));
+
+      expect(find.byIcon(Icons.menu), findsOneWidget);
+    });
+
+    testWidgets('shows both hamburger and back button on sub-pages',
+        (tester) async {
+      await tester.pumpWidget(_buildTestApp(isHomePage: false));
+
+      expect(find.byIcon(Icons.menu), findsOneWidget);
+      expect(find.byIcon(Icons.arrow_back), findsOneWidget);
+    });
+
+    testWidgets('displays app title', (tester) async {
+      await tester.pumpWidget(_buildTestApp());
+
+      expect(find.text('How Many Meeple?'), findsOneWidget);
+    });
+
+    testWidgets('displays subtitle', (tester) async {
+      await tester.pumpWidget(_buildTestApp());
+
+      expect(find.text('Test Subtitle'), findsOneWidget);
+    });
+  });
+}

--- a/test/components/feature_drawer_test.dart
+++ b/test/components/feature_drawer_test.dart
@@ -1,0 +1,182 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:how_many_mobile_meeple/components/feature_drawer.dart';
+import 'package:how_many_mobile_meeple/model/item.dart';
+import 'package:how_many_mobile_meeple/model/model.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+Widget _buildTestApp({AppModel? model}) {
+  final appModel = model ?? AppModel();
+  return ChangeNotifierProvider<AppModel>.value(
+    value: appModel,
+    child: MaterialApp(
+      home: Scaffold(
+        drawer: const FeatureDrawer(),
+        body: Builder(
+          builder: (context) => ElevatedButton(
+            onPressed: () => Scaffold.of(context).openDrawer(),
+            child: const Text('Open Drawer'),
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  group('FeatureDrawer', () {
+    testWidgets('displays Play section header', (tester) async {
+      await tester.pumpWidget(_buildTestApp());
+      await tester.tap(find.text('Open Drawer'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Play'), findsOneWidget);
+    });
+
+    testWidgets('displays Discover section header', (tester) async {
+      await tester.pumpWidget(_buildTestApp());
+      await tester.tap(find.text('Open Drawer'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Discover'), findsOneWidget);
+    });
+
+    testWidgets('displays My Games section header', (tester) async {
+      await tester.pumpWidget(_buildTestApp());
+      await tester.tap(find.text('Open Drawer'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('My Games'), findsOneWidget);
+    });
+
+    testWidgets('displays Quick Pick in Play section', (tester) async {
+      await tester.pumpWidget(_buildTestApp());
+      await tester.tap(find.text('Open Drawer'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Quick Pick'), findsOneWidget);
+    });
+
+    testWidgets('displays Random Game in Play section', (tester) async {
+      await tester.pumpWidget(_buildTestApp());
+      await tester.tap(find.text('Open Drawer'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Random Game'), findsOneWidget);
+    });
+
+    testWidgets('displays View List in Play section', (tester) async {
+      await tester.pumpWidget(_buildTestApp());
+      await tester.tap(find.text('Open Drawer'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('View List'), findsOneWidget);
+    });
+
+    testWidgets('displays Shelf of Shame in Discover section', (tester) async {
+      await tester.pumpWidget(_buildTestApp());
+      await tester.tap(find.text('Open Drawer'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Shelf of Shame'), findsOneWidget);
+    });
+
+    testWidgets('displays Favourites in My Games section', (tester) async {
+      await tester.pumpWidget(_buildTestApp());
+      await tester.tap(find.text('Open Drawer'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Favourites'), findsOneWidget);
+    });
+
+    testWidgets('displays Ignored Games in My Games section', (tester) async {
+      await tester.pumpWidget(_buildTestApp());
+      await tester.tap(find.text('Open Drawer'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Ignored Games'), findsOneWidget);
+    });
+
+    testWidgets('displays Board Game News in My Games section', (tester) async {
+      await tester.pumpWidget(_buildTestApp());
+      await tester.tap(find.text('Open Drawer'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Board Game News'), findsOneWidget);
+    });
+
+    testWidgets('shows snackbar when tapping Quick Pick with no sources',
+        (tester) async {
+      await tester.pumpWidget(_buildTestApp());
+      await tester.tap(find.text('Open Drawer'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Quick Pick'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Add a source first'), findsOneWidget);
+    });
+
+    testWidgets('shows snackbar when tapping Random Game with no sources',
+        (tester) async {
+      await tester.pumpWidget(_buildTestApp());
+      await tester.tap(find.text('Open Drawer'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Random Game'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Add a source first'), findsOneWidget);
+    });
+
+    testWidgets('shows snackbar when tapping View List with no sources',
+        (tester) async {
+      await tester.pumpWidget(_buildTestApp());
+      await tester.tap(find.text('Open Drawer'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('View List'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Add a source first'), findsOneWidget);
+    });
+
+    testWidgets(
+        'shows collection-specific snackbar when tapping Shelf of Shame without collection',
+        (tester) async {
+      final model = AppModel();
+      await model.addItem(Item('trending', itemType: ItemType.hotList));
+
+      await tester.pumpWidget(_buildTestApp(model: model));
+      await tester.tap(find.text('Open Drawer'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Shelf of Shame'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Add a BGG collection first'), findsOneWidget);
+    });
+
+    testWidgets('Play items are enabled when sources exist', (tester) async {
+      final model = AppModel();
+      await model.addItem(Item('testuser'));
+
+      await tester.pumpWidget(_buildTestApp(model: model));
+      await tester.tap(find.text('Open Drawer'));
+      await tester.pumpAndSettle();
+
+      final quickPickTile = tester.widget<ListTile>(find.ancestor(
+        of: find.text('Quick Pick'),
+        matching: find.byType(ListTile),
+      ));
+      expect(quickPickTile.onTap, isNotNull);
+    });
+  });
+}

--- a/test/components/game_image_with_stats_test.dart
+++ b/test/components/game_image_with_stats_test.dart
@@ -2,6 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:how_many_mobile_meeple/components/game_image_with_stats.dart';
 import 'package:how_many_mobile_meeple/model/game.dart';
+import 'package:how_many_mobile_meeple/model/model.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 Game _gameWithRating(double rating) => Game(
       id: 1,
@@ -36,13 +39,20 @@ Game _gameWithPartialData() => Game(
       averageWeight: 0,
     );
 
-Widget _wrapWidget(Widget child) => MaterialApp(
-      home: Scaffold(
-        body: SizedBox(width: 400, height: 600, child: child),
+Widget _wrapWidget(Widget child) => ChangeNotifierProvider<AppModel>.value(
+      value: AppModel(),
+      child: MaterialApp(
+        home: Scaffold(
+          body: SizedBox(width: 400, height: 600, child: child),
+        ),
       ),
     );
 
 void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
   group('GameImageWithStats rating badge', () {
     setUp(() {
       FlutterError.onError = (details) {
@@ -70,10 +80,7 @@ void main() {
       );
 
       expect(find.text('7.5'), findsOneWidget);
-      final sizedBoxes = find.byWidgetPredicate(
-        (w) => w is SizedBox && w.width == 72 && w.height == 72,
-      );
-      expect(sizedBoxes, findsOneWidget);
+      expect(find.byIcon(Icons.star), findsOneWidget);
     });
 
     testWidgets('silver star for rating >= 6.5', (tester) async {
@@ -82,10 +89,7 @@ void main() {
       );
 
       expect(find.text('6.8'), findsOneWidget);
-      final sizedBoxes = find.byWidgetPredicate(
-        (w) => w is SizedBox && w.width == 72 && w.height == 72,
-      );
-      expect(sizedBoxes, findsOneWidget);
+      expect(find.byIcon(Icons.star), findsOneWidget);
     });
 
     testWidgets('bronze star for rating >= 5.5', (tester) async {
@@ -94,10 +98,7 @@ void main() {
       );
 
       expect(find.text('5.9'), findsOneWidget);
-      final sizedBoxes = find.byWidgetPredicate(
-        (w) => w is SizedBox && w.width == 72 && w.height == 72,
-      );
-      expect(sizedBoxes, findsOneWidget);
+      expect(find.byIcon(Icons.star), findsOneWidget);
     });
 
     testWidgets('orange circle for rating >= 4.5', (tester) async {
@@ -106,13 +107,7 @@ void main() {
       );
 
       expect(find.text('4.7'), findsOneWidget);
-      final containers = find.byWidgetPredicate(
-        (w) =>
-            w is Container &&
-            w.constraints?.maxWidth == 56 &&
-            w.constraints?.maxHeight == 56,
-      );
-      expect(containers, findsOneWidget);
+      expect(find.byIcon(Icons.star), findsOneWidget);
     });
 
     testWidgets('red circle for rating < 4.5', (tester) async {
@@ -121,13 +116,7 @@ void main() {
       );
 
       expect(find.text('3.2'), findsOneWidget);
-      final containers = find.byWidgetPredicate(
-        (w) =>
-            w is Container &&
-            w.constraints?.maxWidth == 56 &&
-            w.constraints?.maxHeight == 56,
-      );
-      expect(containers, findsOneWidget);
+      expect(find.byIcon(Icons.star), findsOneWidget);
     });
 
     testWidgets('boundary: 7.4 gets silver not gold', (tester) async {
@@ -197,7 +186,7 @@ void main() {
         _wrapWidget(GameImageWithStats(game: _gameWithNoData())),
       );
 
-      expect(find.text('BoardGameGeek'), findsOneWidget);
+      expect(find.byIcon(Icons.open_in_new), findsOneWidget);
     });
 
     testWidgets('shows only stats that have data', (tester) async {
@@ -208,7 +197,7 @@ void main() {
       expect(find.byIcon(Icons.people), findsOneWidget);
       expect(find.byIcon(Icons.timer), findsNothing);
       expect(find.byIcon(Icons.fitness_center), findsNothing);
-      expect(find.text('BoardGameGeek'), findsOneWidget);
+      expect(find.byIcon(Icons.open_in_new), findsOneWidget);
     });
   });
 }

--- a/test/components/quick_pick_sheet_test.dart
+++ b/test/components/quick_pick_sheet_test.dart
@@ -1,5 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart' as http_testing;
+import 'package:how_many_mobile_meeple/api/http_retry_client.dart';
+import 'package:how_many_mobile_meeple/api/plays_service.dart';
 import 'package:how_many_mobile_meeple/components/quick_pick_sheet.dart';
 import 'package:how_many_mobile_meeple/model/item.dart';
 import 'package:how_many_mobile_meeple/model/model.dart';
@@ -40,6 +44,17 @@ void main() {
 
   setUp(() {
     SharedPreferences.setMockInitialValues({});
+    PlaysService.clearCache();
+    HttpRetryClient.setDelayFunction((_) async {});
+    HttpRetryClient.setTestClient(
+      http_testing.MockClient((request) async => http.Response('[]', 200)),
+    );
+  });
+
+  tearDown(() {
+    HttpRetryClient.resetTestClient();
+    HttpRetryClient.resetDelayFunction();
+    PlaysService.clearCache();
   });
 
   group('QuickPickSheet', () {
@@ -268,6 +283,65 @@ void main() {
           defaultMaxTime);
       expect(model.settings.setting(Settings.filterComplexity.name).value,
           defaultComplexity);
+    });
+
+    testWidgets('displays Unplayed only toggle', (tester) async {
+      final model = AppModel();
+      await model.addItem(Item('testuser'));
+      await tester.pumpWidget(_buildTestApp(model: model));
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Unplayed only'), findsOneWidget);
+      expect(find.byIcon(Icons.shelves), findsOneWidget);
+    });
+
+    testWidgets('Unplayed toggle disabled without primary player',
+        (tester) async {
+      final model = AppModel();
+      await model.addItem(Item('trending', itemType: ItemType.hotList));
+      await tester.pumpWidget(_buildTestApp(model: model));
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      final switches = tester.widgetList<Switch>(find.byType(Switch)).toList();
+      final sosSwitch = switches.last;
+      expect(sosSwitch.onChanged, isNull);
+    });
+
+    testWidgets('Unplayed toggle applies on Go', (tester) async {
+      final model = AppModel();
+      await model.addItem(Item('testuser'));
+      await tester.pumpWidget(_buildTestApp(model: model));
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byType(Switch));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Go!'));
+      await tester.pumpAndSettle();
+
+      final setting =
+          model.settings.setting(Settings.filterShelfOfShameOnly.name);
+      expect(setting.enabled, isTrue);
+      expect(setting.getBool(), isTrue);
+    });
+
+    testWidgets('restores Unplayed toggle from model', (tester) async {
+      final model = AppModel();
+      await model.addItem(Item('testuser'));
+      final setting =
+          model.settings.setting(Settings.filterShelfOfShameOnly.name);
+      setting.value = true;
+      setting.enabled = true;
+      model.settings.updateSetting(setting);
+
+      await tester.pumpWidget(_buildTestApp(model: model));
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      final sw = tester.widget<Switch>(find.byType(Switch));
+      expect(sw.value, isTrue);
     });
   });
 }

--- a/test/components/unplayed_only_toggle_test.dart
+++ b/test/components/unplayed_only_toggle_test.dart
@@ -1,0 +1,109 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart' as http_testing;
+import 'package:how_many_mobile_meeple/api/http_retry_client.dart';
+import 'package:how_many_mobile_meeple/api/plays_service.dart';
+import 'package:how_many_mobile_meeple/components/unplayed_only_toggle.dart';
+import 'package:how_many_mobile_meeple/model/item.dart';
+import 'package:how_many_mobile_meeple/model/model.dart';
+import 'package:how_many_mobile_meeple/model/settings.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+Widget _wrap(Widget child, AppModel model) {
+  return ChangeNotifierProvider<AppModel>.value(
+    value: model,
+    child: MaterialApp(home: Scaffold(body: child)),
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    PlaysService.clearCache();
+    HttpRetryClient.setDelayFunction((_) async {});
+    HttpRetryClient.setTestClient(
+      http_testing.MockClient((request) async => http.Response('[]', 200)),
+    );
+  });
+
+  tearDown(() {
+    HttpRetryClient.resetTestClient();
+    HttpRetryClient.resetDelayFunction();
+    PlaysService.clearCache();
+  });
+
+  group('UnplayedOnlyToggle card style', () {
+    testWidgets('shows label and switch', (tester) async {
+      final model = AppModel();
+      await model.addItem(Item('testuser'));
+      await tester.pumpWidget(_wrap(const UnplayedOnlyToggle(), model));
+
+      expect(find.text('Unplayed only'), findsOneWidget);
+      expect(find.byType(Switch), findsOneWidget);
+    });
+
+    testWidgets('switch is disabled without primary player', (tester) async {
+      final model = AppModel();
+      await tester.pumpWidget(_wrap(const UnplayedOnlyToggle(), model));
+
+      final sw = tester.widget<Switch>(find.byType(Switch));
+      expect(sw.onChanged, isNull);
+    });
+
+    testWidgets('switch is enabled with primary player', (tester) async {
+      final model = AppModel();
+      await model.addItem(Item('testuser'));
+      await tester.pumpWidget(_wrap(const UnplayedOnlyToggle(), model));
+
+      final sw = tester.widget<Switch>(find.byType(Switch));
+      expect(sw.onChanged, isNotNull);
+    });
+
+    testWidgets('toggling updates model setting', (tester) async {
+      final model = AppModel();
+      await model.addItem(Item('testuser'));
+      await tester.pumpWidget(_wrap(const UnplayedOnlyToggle(), model));
+
+      await tester.tap(find.byType(Switch));
+      await tester.pumpAndSettle();
+
+      final setting =
+          model.settings.setting(Settings.filterShelfOfShameOnly.name);
+      expect(setting.enabled, isTrue);
+      expect(setting.getBool(), isTrue);
+    });
+
+    testWidgets('toggling off disables setting', (tester) async {
+      final model = AppModel();
+      await model.addItem(Item('testuser'));
+      final setting =
+          model.settings.setting(Settings.filterShelfOfShameOnly.name);
+      setting.value = true;
+      setting.enabled = true;
+      model.settings.updateSetting(setting);
+
+      await tester.pumpWidget(_wrap(const UnplayedOnlyToggle(), model));
+      await tester.tap(find.byType(Switch));
+      await tester.pumpAndSettle();
+
+      expect(setting.enabled, isFalse);
+    });
+  });
+
+  group('UnplayedOnlyToggle compact style', () {
+    testWidgets('shows compact label', (tester) async {
+      final model = AppModel();
+      await model.addItem(Item('testuser'));
+      await tester.pumpWidget(_wrap(
+        const UnplayedOnlyToggle(style: UnplayedToggleStyle.compact),
+        model,
+      ));
+
+      expect(find.text('Unplayed Only (Shelf of Shame)'), findsOneWidget);
+    });
+  });
+}

--- a/test/guided_flow/step1_primary_player_test.dart
+++ b/test/guided_flow/step1_primary_player_test.dart
@@ -1,0 +1,126 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart' as http_testing;
+import 'package:how_many_mobile_meeple/api/http_retry_client.dart';
+import 'package:how_many_mobile_meeple/api/plays_service.dart';
+import 'package:how_many_mobile_meeple/guided_flow/step1_select_source.dart';
+import 'package:how_many_mobile_meeple/model/item.dart';
+import 'package:how_many_mobile_meeple/model/model.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+Widget _buildTestApp(AppModel model) {
+  return ChangeNotifierProvider<AppModel>.value(
+    value: model,
+    child: MaterialApp(
+      home: Scaffold(
+        body: SingleChildScrollView(
+          child: const Step1SelectSource(),
+        ),
+      ),
+    ),
+  );
+}
+
+Finder _findCrowns() => find.byWidgetPredicate(
+    (w) => w is FaIcon && w.icon == FontAwesomeIcons.crown.data);
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({
+      'tour_tip_seen_step1_tab_selector': true,
+      'tour_tip_seen_step1_trending': true,
+      'tour_tip_seen_step1_collection': true,
+      'tour_tip_seen_step1_geeklist': true,
+    });
+    PlaysService.clearCache();
+    HttpRetryClient.setDelayFunction((_) async {});
+    HttpRetryClient.setTestClient(
+      http_testing.MockClient((request) async => http.Response('[]', 200)),
+    );
+  });
+
+  tearDown(() {
+    HttpRetryClient.resetTestClient();
+    HttpRetryClient.resetDelayFunction();
+    PlaysService.clearCache();
+  });
+
+  group('Step1 Primary Player Crown', () {
+    testWidgets('shows crown for collection items', (tester) async {
+      final model = AppModel();
+      await model.addItem(Item('teqqles'));
+
+      await tester.pumpWidget(_buildTestApp(model));
+      await tester.pump();
+
+      expect(_findCrowns(), findsOneWidget);
+    });
+
+    testWidgets('does not show crown for hotList items', (tester) async {
+      final model = AppModel();
+      await model.addItem(Item('trending', itemType: ItemType.hotList));
+
+      await tester.pumpWidget(_buildTestApp(model));
+      await tester.pump();
+
+      expect(_findCrowns(), findsNothing);
+    });
+
+    testWidgets('does not show crown for geekList items', (tester) async {
+      final model = AppModel();
+      await model.addItem(Item('12345', itemType: ItemType.geekList));
+
+      await tester.pumpWidget(_buildTestApp(model));
+      await tester.pump();
+
+      expect(_findCrowns(), findsNothing);
+    });
+
+    testWidgets('first collection item has gold crown by default',
+        (tester) async {
+      final model = AppModel();
+      await model.addItem(Item('teqqles'));
+
+      await tester.pumpWidget(_buildTestApp(model));
+      await tester.pump();
+
+      final crownIcon = tester.widget<FaIcon>(_findCrowns());
+      expect(crownIcon.color, Colors.amber);
+    });
+
+    testWidgets('second collection item has grey crown', (tester) async {
+      final model = AppModel();
+      await model.addItem(Item('teqqles'));
+      await model.addItem(Item('otheruser'));
+
+      await tester.pumpWidget(_buildTestApp(model));
+      await tester.pump();
+
+      final crowns = tester.widgetList<FaIcon>(_findCrowns()).toList();
+
+      expect(crowns.length, 2);
+      expect(crowns[0].color, Colors.amber);
+      expect(crowns[1].color, Colors.grey);
+    });
+
+    testWidgets('tapping grey crown makes it primary player', (tester) async {
+      final model = AppModel();
+      await model.addItem(Item('teqqles'));
+      await model.addItem(Item('otheruser'));
+
+      await tester.pumpWidget(_buildTestApp(model));
+      await tester.pump();
+
+      final crownButtons = _findCrowns();
+      await tester.tap(crownButtons.last);
+      await tester.pump();
+
+      expect(model.primaryPlayer, 'otheruser');
+    });
+  });
+}

--- a/test/model/app_model_plays_test.dart
+++ b/test/model/app_model_plays_test.dart
@@ -1,0 +1,352 @@
+import 'dart:convert';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart' as http_testing;
+import 'package:how_many_mobile_meeple/api/http_retry_client.dart';
+import 'package:how_many_mobile_meeple/api/plays_service.dart';
+import 'package:how_many_mobile_meeple/model/item.dart';
+import 'package:how_many_mobile_meeple/model/model.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    PlaysService.clearCache();
+    HttpRetryClient.setDelayFunction((_) async {});
+  });
+
+  tearDown(() {
+    HttpRetryClient.resetTestClient();
+    HttpRetryClient.resetDelayFunction();
+    PlaysService.clearCache();
+  });
+
+  group('AppModel plays integration', () {
+    test('getPlayCount returns 0 when plays not loaded', () {
+      final model = AppModel();
+      expect(model.getPlayCount(123), 0);
+    });
+
+    test('isUnplayed returns true when plays not loaded', () {
+      final model = AppModel();
+      expect(model.isUnplayed(123), isTrue);
+    });
+
+    test('loadPlays fetches and stores play data', () async {
+      HttpRetryClient.setTestClient(
+        http_testing.MockClient((request) async {
+          if (request.url.path.startsWith('/plays/')) {
+            return http.Response(
+              jsonEncode([
+                {'game_id': 1, 'game_name': 'Wingspan', 'total_plays': 5},
+                {'game_id': 2, 'game_name': 'Catan', 'total_plays': 0},
+              ]),
+              200,
+            );
+          }
+          return http.Response('[]', 200);
+        }),
+      );
+
+      final model = AppModel();
+      await model.addItem(Item('testuser'));
+      await model.loadPlays();
+
+      expect(model.getPlayCount(1), 5);
+      expect(model.getPlayCount(2), 0);
+    });
+
+    test('getPlayCount returns correct count after loading', () async {
+      HttpRetryClient.setTestClient(
+        http_testing.MockClient((request) async {
+          if (request.url.path.startsWith('/plays/')) {
+            return http.Response(
+              jsonEncode([
+                {'game_id': 42, 'game_name': 'Azul', 'total_plays': 7},
+              ]),
+              200,
+            );
+          }
+          return http.Response('[]', 200);
+        }),
+      );
+
+      final model = AppModel();
+      await model.addItem(Item('testuser'));
+      await model.loadPlays();
+
+      expect(model.getPlayCount(42), 7);
+    });
+
+    test('getPlayCount returns 0 for games not in plays data', () async {
+      HttpRetryClient.setTestClient(
+        http_testing.MockClient((request) async {
+          if (request.url.path.startsWith('/plays/')) {
+            return http.Response(
+              jsonEncode([
+                {'game_id': 1, 'game_name': 'Wingspan', 'total_plays': 5},
+              ]),
+              200,
+            );
+          }
+          return http.Response('[]', 200);
+        }),
+      );
+
+      final model = AppModel();
+      await model.addItem(Item('testuser'));
+      await model.loadPlays();
+
+      expect(model.getPlayCount(999), 0);
+    });
+
+    test('isUnplayed returns true for games with 0 plays', () async {
+      HttpRetryClient.setTestClient(
+        http_testing.MockClient((request) async {
+          if (request.url.path.startsWith('/plays/')) {
+            return http.Response(
+              jsonEncode([
+                {'game_id': 1, 'game_name': 'Wingspan', 'total_plays': 5},
+                {'game_id': 2, 'game_name': 'Catan', 'total_plays': 0},
+              ]),
+              200,
+            );
+          }
+          return http.Response('[]', 200);
+        }),
+      );
+
+      final model = AppModel();
+      await model.addItem(Item('testuser'));
+      await model.loadPlays();
+
+      expect(model.isUnplayed(2), isTrue);
+    });
+
+    test('isUnplayed returns true for games not in plays data', () async {
+      HttpRetryClient.setTestClient(
+        http_testing.MockClient((request) async {
+          if (request.url.path.startsWith('/plays/')) {
+            return http.Response(
+              jsonEncode([
+                {'game_id': 1, 'game_name': 'Wingspan', 'total_plays': 5},
+              ]),
+              200,
+            );
+          }
+          return http.Response('[]', 200);
+        }),
+      );
+
+      final model = AppModel();
+      await model.addItem(Item('testuser'));
+      await model.loadPlays();
+
+      expect(model.isUnplayed(999), isTrue);
+    });
+
+    test('isUnplayed returns false for games with plays', () async {
+      HttpRetryClient.setTestClient(
+        http_testing.MockClient((request) async {
+          if (request.url.path.startsWith('/plays/')) {
+            return http.Response(
+              jsonEncode([
+                {'game_id': 1, 'game_name': 'Wingspan', 'total_plays': 5},
+              ]),
+              200,
+            );
+          }
+          return http.Response('[]', 200);
+        }),
+      );
+
+      final model = AppModel();
+      await model.addItem(Item('testuser'));
+      await model.loadPlays();
+
+      expect(model.isUnplayed(1), isFalse);
+    });
+
+    test('loadPlays does nothing when no primary player set', () async {
+      int callCount = 0;
+      HttpRetryClient.setTestClient(
+        http_testing.MockClient((request) async {
+          callCount++;
+          return http.Response('[]', 200);
+        }),
+      );
+
+      final model = AppModel();
+      await model.addItem(Item('trending', itemType: ItemType.hotList));
+      await model.loadPlays();
+
+      expect(callCount, 0);
+    });
+
+    test('loadPlays uses primary player username', () async {
+      final capturedPaths = <String>[];
+      HttpRetryClient.setTestClient(
+        http_testing.MockClient((request) async {
+          capturedPaths.add(request.url.path);
+          return http.Response('[]', 200);
+        }),
+      );
+
+      final model = AppModel();
+      await model.addItem(Item('teqqles'));
+      await model.loadPlays();
+
+      expect(capturedPaths, contains('/plays/teqqles'));
+      expect(capturedPaths, contains('/collection/teqqles'));
+    });
+
+    test('isInCollection returns true for games in collection', () async {
+      HttpRetryClient.setTestClient(
+        http_testing.MockClient((request) async {
+          if (request.url.path.startsWith('/plays/')) {
+            return http.Response('[]', 200);
+          }
+          if (request.url.path.startsWith('/collection/')) {
+            return http.Response(
+              jsonEncode([
+                {
+                  'id': 1,
+                  'name': 'Wingspan',
+                  'minplayers': 1,
+                  'maxplayers': 5,
+                  'maxplaytime': 70,
+                  'image': null,
+                  'thumbnail': null,
+                  'stats': {'average': 8.0, 'averageweight': 2.5},
+                },
+              ]),
+              200,
+            );
+          }
+          return http.Response('[]', 200);
+        }),
+      );
+
+      final model = AppModel();
+      await model.addItem(Item('testuser'));
+      await model.loadPlays();
+
+      expect(model.isInCollection(1), isTrue);
+      expect(model.isInCollection(999), isFalse);
+    });
+
+    test('playsLoaded is false initially', () {
+      final model = AppModel();
+      expect(model.playsLoaded, isFalse);
+    });
+
+    test('playsLoaded is true after successful load', () async {
+      HttpRetryClient.setTestClient(
+        http_testing.MockClient((request) async {
+          return http.Response('[]', 200);
+        }),
+      );
+
+      final model = AppModel();
+      await model.addItem(Item('testuser'));
+      await model.loadPlays();
+
+      expect(model.playsLoaded, isTrue);
+    });
+
+    test('notifies listeners when plays load completes', () async {
+      HttpRetryClient.setTestClient(
+        http_testing.MockClient((request) async {
+          return http.Response('[]', 200);
+        }),
+      );
+
+      final model = AppModel();
+      await model.addItem(Item('testuser'));
+
+      int notifyCount = 0;
+      model.addListener(() => notifyCount++);
+
+      await model.loadPlays();
+
+      expect(notifyCount, greaterThan(0));
+    });
+
+    test('loadStoredData triggers loadPlays when primary player exists',
+        () async {
+      final capturedPaths = <String>[];
+      HttpRetryClient.setTestClient(
+        http_testing.MockClient((request) async {
+          capturedPaths.add(request.url.path);
+          return http.Response('[]', 200);
+        }),
+      );
+
+      SharedPreferences.setMockInitialValues({
+        'primary_player': 'storeduser',
+        'item_0': '{"name":"storeduser","item_type":{"name":"collection"}}',
+      });
+
+      final model = AppModel();
+      await model.loadStoredData();
+      await Future.delayed(Duration.zero);
+
+      expect(capturedPaths, contains('/plays/storeduser'));
+      expect(capturedPaths, contains('/collection/storeduser'));
+    });
+
+    test('primaryPlayer setter triggers loadPlays', () async {
+      final capturedPaths = <String>[];
+      HttpRetryClient.setTestClient(
+        http_testing.MockClient((request) async {
+          capturedPaths.add(request.url.path);
+          return http.Response('[]', 200);
+        }),
+      );
+
+      final model = AppModel();
+      await model.addItem(Item('user1'));
+      await model.addItem(Item('user2'));
+      capturedPaths.clear();
+
+      model.primaryPlayer = 'user2';
+      await Future.delayed(Duration.zero);
+
+      expect(capturedPaths, contains('/plays/user2'));
+      expect(capturedPaths, contains('/collection/user2'));
+    });
+
+    test('primaryPlayer setter resets plays state', () async {
+      HttpRetryClient.setTestClient(
+        http_testing.MockClient((request) async {
+          if (request.url.path.startsWith('/plays/')) {
+            return http.Response(
+              jsonEncode([
+                {'game_id': 1, 'game_name': 'Wingspan', 'total_plays': 5},
+              ]),
+              200,
+            );
+          }
+          return http.Response('[]', 200);
+        }),
+      );
+
+      final model = AppModel();
+      await model.addItem(Item('user1'));
+      await model.addItem(Item('user2'));
+      await model.loadPlays();
+      expect(model.playsLoaded, isTrue);
+      expect(model.getPlayCount(1), 5);
+
+      HttpRetryClient.setTestClient(
+        http_testing.MockClient((request) async => http.Response('[]', 200)),
+      );
+      model.primaryPlayer = 'user2';
+
+      expect(model.playsLoaded, isFalse);
+      expect(model.getPlayCount(1), 0);
+    });
+  });
+}

--- a/test/model/app_model_primary_player_test.dart
+++ b/test/model/app_model_primary_player_test.dart
@@ -1,0 +1,156 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart' as http_testing;
+import 'package:how_many_mobile_meeple/api/http_retry_client.dart';
+import 'package:how_many_mobile_meeple/api/plays_service.dart';
+import 'package:how_many_mobile_meeple/model/item.dart';
+import 'package:how_many_mobile_meeple/model/model.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    PlaysService.clearCache();
+    HttpRetryClient.setDelayFunction((_) async {});
+    HttpRetryClient.setTestClient(
+      http_testing.MockClient((request) async => http.Response('[]', 200)),
+    );
+  });
+
+  tearDown(() {
+    HttpRetryClient.resetTestClient();
+    HttpRetryClient.resetDelayFunction();
+    PlaysService.clearCache();
+  });
+
+  group('AppModel.primaryPlayer', () {
+    test('defaults to null when no collections added', () {
+      final model = AppModel();
+      expect(model.primaryPlayer, isNull);
+    });
+
+    test('auto-sets to first collection item added', () async {
+      final model = AppModel();
+      await model.addItem(Item('teqqles'));
+
+      expect(model.primaryPlayer, 'teqqles');
+    });
+
+    test('does not auto-set for geekList items', () async {
+      final model = AppModel();
+      await model.addItem(Item('12345', itemType: ItemType.geekList));
+
+      expect(model.primaryPlayer, isNull);
+    });
+
+    test('does not auto-set for hotList items', () async {
+      final model = AppModel();
+      await model.addItem(Item('trending', itemType: ItemType.hotList));
+
+      expect(model.primaryPlayer, isNull);
+    });
+
+    test(
+        'does not override existing primary player when adding more collections',
+        () async {
+      final model = AppModel();
+      await model.addItem(Item('teqqles'));
+      await model.addItem(Item('otheruser'));
+
+      expect(model.primaryPlayer, 'teqqles');
+    });
+
+    test('can be set explicitly', () async {
+      final model = AppModel();
+      await model.addItem(Item('teqqles'));
+      await model.addItem(Item('otheruser'));
+
+      model.primaryPlayer = 'otheruser';
+
+      expect(model.primaryPlayer, 'otheruser');
+    });
+
+    test('resets to next collection when primary player item is deleted',
+        () async {
+      final model = AppModel();
+      await model.addItem(Item('teqqles'));
+      await model.addItem(Item('otheruser'));
+
+      expect(model.primaryPlayer, 'teqqles');
+
+      await model.deleteItem(Item('teqqles'));
+
+      expect(model.primaryPlayer, 'otheruser');
+    });
+
+    test('resets to null when last collection item is deleted', () async {
+      final model = AppModel();
+      await model.addItem(Item('teqqles'));
+
+      expect(model.primaryPlayer, 'teqqles');
+
+      await model.deleteItem(Item('teqqles'));
+
+      expect(model.primaryPlayer, isNull);
+    });
+
+    test('is not affected by deleting non-primary collection items', () async {
+      final model = AppModel();
+      await model.addItem(Item('teqqles'));
+      await model.addItem(Item('otheruser'));
+
+      await model.deleteItem(Item('otheruser'));
+
+      expect(model.primaryPlayer, 'teqqles');
+    });
+
+    test('persists across store operations', () async {
+      final model = AppModel();
+      await model.addItem(Item('teqqles'));
+
+      expect(model.primaryPlayer, 'teqqles');
+
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getString('primary_player'), 'teqqles');
+    });
+
+    test('loads persisted primary player on loadStoredData', () async {
+      SharedPreferences.setMockInitialValues({
+        'primary_player': 'saveduser',
+        'item_0': '{"name":"saveduser","item_type":{"name":"collection"}}',
+      });
+
+      final model = AppModel();
+      await model.loadStoredData();
+
+      expect(model.primaryPlayer, 'saveduser');
+    });
+
+    test('notifies listeners when primary player changes', () async {
+      final model = AppModel();
+      await model.addItem(Item('teqqles'));
+      await model.addItem(Item('otheruser'));
+
+      int notifyCount = 0;
+      model.addListener(() => notifyCount++);
+
+      model.primaryPlayer = 'otheruser';
+
+      expect(notifyCount, 1);
+    });
+
+    test('does not notify if setting same primary player', () async {
+      final model = AppModel();
+      await model.addItem(Item('teqqles'));
+
+      int notifyCount = 0;
+      model.addListener(() => notifyCount++);
+
+      model.primaryPlayer = 'teqqles';
+
+      expect(notifyCount, 0);
+    });
+  });
+}

--- a/test/model/play_data_test.dart
+++ b/test/model/play_data_test.dart
@@ -1,0 +1,66 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:how_many_mobile_meeple/model/play_data.dart';
+
+void main() {
+  group('PlayData', () {
+    test('fromJson parses complete play data', () {
+      final json = {
+        'game_id': 123,
+        'game_name': 'Wingspan',
+        'total_plays': 5,
+      };
+
+      final playData = PlayData.fromJson(json);
+
+      expect(playData.gameId, 123);
+      expect(playData.gameName, 'Wingspan');
+      expect(playData.totalPlays, 5);
+    });
+
+    test('fromJson defaults totalPlays to 0 when missing', () {
+      final json = {
+        'game_id': 456,
+        'game_name': 'Catan',
+      };
+
+      final playData = PlayData.fromJson(json);
+
+      expect(playData.totalPlays, 0);
+    });
+
+    test('fromJson defaults totalPlays to 0 when null', () {
+      final json = {
+        'game_id': 789,
+        'game_name': 'Azul',
+        'total_plays': null,
+      };
+
+      final playData = PlayData.fromJson(json);
+
+      expect(playData.totalPlays, 0);
+    });
+
+    test('equality is based on gameId', () {
+      final play1 = PlayData(gameId: 1, gameName: 'Wingspan', totalPlays: 5);
+      final play2 = PlayData(gameId: 1, gameName: 'Wingspan', totalPlays: 10);
+      final play3 = PlayData(gameId: 2, gameName: 'Catan', totalPlays: 5);
+
+      expect(play1, equals(play2));
+      expect(play1, isNot(equals(play3)));
+    });
+
+    test('hashCode is consistent with equality', () {
+      final play1 = PlayData(gameId: 1, gameName: 'Wingspan', totalPlays: 5);
+      final play2 = PlayData(gameId: 1, gameName: 'Wingspan', totalPlays: 10);
+
+      expect(play1.hashCode, equals(play2.hashCode));
+    });
+
+    test('toString returns descriptive string', () {
+      final playData =
+          PlayData(gameId: 123, gameName: 'Wingspan', totalPlays: 5);
+
+      expect(playData.toString(), 'Wingspan (id: 123, plays: 5)');
+    });
+  });
+}

--- a/test/platform/router_test.dart
+++ b/test/platform/router_test.dart
@@ -36,9 +36,42 @@ void main() {
     });
 
     test('extracts base route from nested path', () {
-      // Route with nested path should extract the base route
       final route =
           r.Router.generateRoute(RouteSettings(name: '/random/extra/path'));
+      expect(route, isA<MaterialPageRoute>());
+    });
+
+    test('handles shelf-of-shame route', () {
+      final route =
+          r.Router.generateRoute(RouteSettings(name: '/shelf-of-shame'));
+      expect(route, isA<MaterialPageRoute>());
+    });
+
+    test('handles shelf-of-shame route with username', () {
+      final route = r.Router.generateRoute(
+          RouteSettings(name: '/shelf-of-shame/testuser'));
+      expect(route, isA<MaterialPageRoute>());
+    });
+
+    test('handles shelf-of-shame route with encoded username', () {
+      final route = r.Router.generateRoute(
+          RouteSettings(name: '/shelf-of-shame/user%20name'));
+      expect(route, isA<MaterialPageRoute>());
+    });
+
+    test('handles game detail route with id', () {
+      final route =
+          r.Router.generateRoute(RouteSettings(name: '/game/Wingspan/174430'));
+      expect(route, isA<MaterialPageRoute>());
+    });
+
+    test('handles favourites route', () {
+      final route = r.Router.generateRoute(RouteSettings(name: '/favourites'));
+      expect(route, isA<MaterialPageRoute>());
+    });
+
+    test('handles ignored route', () {
+      final route = r.Router.generateRoute(RouteSettings(name: '/ignored'));
       expect(route, isA<MaterialPageRoute>());
     });
   });

--- a/test/shelf_of_shame/shelf_of_shame_page_test.dart
+++ b/test/shelf_of_shame/shelf_of_shame_page_test.dart
@@ -1,0 +1,296 @@
+import 'dart:async';
+import 'dart:convert';
+import 'package:flutter/material.dart';
+import 'package:flutter_spinkit/flutter_spinkit.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart' as http_testing;
+import 'package:how_many_mobile_meeple/api/http_retry_client.dart';
+import 'package:how_many_mobile_meeple/api/plays_service.dart';
+import 'package:how_many_mobile_meeple/model/item.dart';
+import 'package:how_many_mobile_meeple/model/model.dart';
+import 'package:how_many_mobile_meeple/shelf_of_shame/shelf_of_shame_page.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+Widget _buildTestApp(AppModel model) {
+  return ChangeNotifierProvider<AppModel>.value(
+    value: model,
+    child: MaterialApp(
+      home: const ShelfOfShamePage(),
+    ),
+  );
+}
+
+http_testing.MockClient _mockClient({
+  required List<Map<String, dynamic>> collectionGames,
+  required List<Map<String, dynamic>> playsData,
+}) {
+  return http_testing.MockClient((request) async {
+    if (request.url.path.startsWith('/plays/')) {
+      return http.Response(jsonEncode(playsData), 200);
+    }
+    if (request.url.path.startsWith('/collection/')) {
+      return http.Response(jsonEncode(collectionGames), 200);
+    }
+    return http.Response('Not found', 404);
+  });
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    PlaysService.clearCache();
+    HttpRetryClient.setDelayFunction((_) async {});
+  });
+
+  tearDown(() {
+    HttpRetryClient.resetTestClient();
+    HttpRetryClient.resetDelayFunction();
+    PlaysService.clearCache();
+  });
+
+  group('ShelfOfShamePage', () {
+    testWidgets('shows no collection message when no collection added',
+        (tester) async {
+      HttpRetryClient.setTestClient(
+        http_testing.MockClient((_) async => http.Response('[]', 200)),
+      );
+
+      final model = AppModel();
+      await model.addItem(Item('trending', itemType: ItemType.hotList));
+
+      await tester.pumpWidget(_buildTestApp(model));
+      await tester.pumpAndSettle();
+
+      expect(find.text('No collection added'), findsOneWidget);
+      expect(find.textContaining('requires a BGG collection'), findsOneWidget);
+    });
+
+    testWidgets(
+        'shows no primary player message when collection exists but no player set',
+        (tester) async {
+      HttpRetryClient.setTestClient(
+        http_testing.MockClient((_) async => http.Response('[]', 200)),
+      );
+
+      final model = AppModel();
+      await model.addItem(Item('testuser'));
+      model.primaryPlayer = null;
+
+      await tester.pumpWidget(_buildTestApp(model));
+      await tester.pumpAndSettle();
+
+      expect(find.text('No primary player set'), findsOneWidget);
+      expect(find.textContaining('crown icon'), findsOneWidget);
+    });
+
+    testWidgets('shows loading indicator while fetching', (tester) async {
+      final completer = Completer<http.Response>();
+      HttpRetryClient.setTestClient(
+        http_testing.MockClient((request) {
+          if (request.url.path.startsWith('/plays/')) {
+            return completer.future;
+          }
+          return Future.value(http.Response('[]', 200));
+        }),
+      );
+
+      final model = AppModel();
+      await model.addItem(Item('testuser'));
+
+      await tester.pumpWidget(_buildTestApp(model));
+      await tester.pump();
+
+      expect(find.byType(SpinKitCubeGrid), findsOneWidget);
+
+      completer.complete(http.Response('[]', 200));
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('shows collection banner with primary player name',
+        (tester) async {
+      HttpRetryClient.setTestClient(_mockClient(
+        collectionGames: [
+          _gameJson(1, 'Wingspan'),
+          _gameJson(2, 'Catan'),
+        ],
+        playsData: [
+          {'game_id': 1, 'game_name': 'Wingspan', 'total_plays': 5},
+        ],
+      ));
+
+      final model = AppModel();
+      await model.addItem(Item('teqqles'));
+
+      await tester.pumpWidget(_buildTestApp(model));
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining("teqqles's collection"), findsOneWidget);
+    });
+
+    testWidgets('shows only unplayed games from full collection',
+        (tester) async {
+      HttpRetryClient.setTestClient(_mockClient(
+        collectionGames: [
+          _gameJson(1, 'Wingspan'),
+          _gameJson(2, 'Catan'),
+          _gameJson(3, 'Azul'),
+        ],
+        playsData: [
+          {'game_id': 1, 'game_name': 'Wingspan', 'total_plays': 5},
+          {'game_id': 2, 'game_name': 'Catan', 'total_plays': 0},
+        ],
+      ));
+
+      final model = AppModel();
+      await model.addItem(Item('testuser'));
+
+      await tester.pumpWidget(_buildTestApp(model));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Catan'), findsOneWidget);
+      expect(find.text('Azul'), findsOneWidget);
+      expect(find.text('Wingspan'), findsNothing);
+    });
+
+    testWidgets('shows unplayed count in banner', (tester) async {
+      HttpRetryClient.setTestClient(_mockClient(
+        collectionGames: [
+          _gameJson(1, 'Wingspan'),
+          _gameJson(2, 'Catan'),
+          _gameJson(3, 'Azul'),
+        ],
+        playsData: [
+          {'game_id': 1, 'game_name': 'Wingspan', 'total_plays': 5},
+          {'game_id': 2, 'game_name': 'Catan', 'total_plays': 0},
+          {'game_id': 3, 'game_name': 'Azul', 'total_plays': 0},
+        ],
+      ));
+
+      final model = AppModel();
+      await model.addItem(Item('testuser'));
+
+      await tester.pumpWidget(_buildTestApp(model));
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('2 unplayed'), findsOneWidget);
+    });
+
+    testWidgets('shows celebration message when all games played',
+        (tester) async {
+      HttpRetryClient.setTestClient(_mockClient(
+        collectionGames: [
+          _gameJson(1, 'Wingspan'),
+          _gameJson(2, 'Catan'),
+        ],
+        playsData: [
+          {'game_id': 1, 'game_name': 'Wingspan', 'total_plays': 5},
+          {'game_id': 2, 'game_name': 'Catan', 'total_plays': 3},
+        ],
+      ));
+
+      final model = AppModel();
+      await model.addItem(Item('testuser'));
+
+      await tester.pumpWidget(_buildTestApp(model));
+      await tester.pumpAndSettle();
+
+      expect(find.text('No shame here!'), findsOneWidget);
+    });
+
+    testWidgets('shows BG Stats plug at bottom of list', (tester) async {
+      HttpRetryClient.setTestClient(_mockClient(
+        collectionGames: [
+          _gameJson(1, 'Wingspan'),
+        ],
+        playsData: [
+          {'game_id': 1, 'game_name': 'Wingspan', 'total_plays': 0},
+        ],
+      ));
+
+      final model = AppModel();
+      await model.addItem(Item('testuser'));
+
+      await tester.pumpWidget(_buildTestApp(model));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Track your plays'), findsOneWidget);
+      expect(find.textContaining('BG Stats'), findsOneWidget);
+    });
+
+    testWidgets('shows app bar with correct title', (tester) async {
+      HttpRetryClient.setTestClient(
+        http_testing.MockClient((_) async => http.Response('[]', 200)),
+      );
+
+      final model = AppModel();
+
+      await tester.pumpWidget(_buildTestApp(model));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Shelf of Shame'), findsOneWidget);
+    });
+
+    testWidgets('games with no play data are shown as unplayed',
+        (tester) async {
+      HttpRetryClient.setTestClient(_mockClient(
+        collectionGames: [
+          _gameJson(1, 'Wingspan'),
+          _gameJson(2, 'Catan'),
+          _gameJson(3, 'Azul'),
+        ],
+        playsData: [
+          {'game_id': 1, 'game_name': 'Wingspan', 'total_plays': 3},
+        ],
+      ));
+
+      final model = AppModel();
+      await model.addItem(Item('testuser'));
+
+      await tester.pumpWidget(_buildTestApp(model));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Catan'), findsOneWidget);
+      expect(find.text('Azul'), findsOneWidget);
+      expect(find.text('Wingspan'), findsNothing);
+    });
+
+    testWidgets('fetches full unfiltered collection', (tester) async {
+      Map<String, String>? capturedHeaders;
+      HttpRetryClient.setTestClient(
+        http_testing.MockClient((request) async {
+          if (request.url.path.startsWith('/collection/')) {
+            capturedHeaders = request.headers;
+            return http.Response(jsonEncode([_gameJson(1, 'Wingspan')]), 200);
+          }
+          return http.Response('[]', 200);
+        }),
+      );
+
+      final model = AppModel();
+      await model.addItem(Item('testuser'));
+
+      await tester.pumpWidget(_buildTestApp(model));
+      await tester.pumpAndSettle();
+
+      expect(capturedHeaders, isNotNull);
+      expect(capturedHeaders!.containsKey('Bgg-Field-Whitelist'), isTrue);
+      expect(capturedHeaders!.containsKey('Bgg-Filter-Player-Count'), isFalse);
+      expect(capturedHeaders!.containsKey('Bgg-Filter-Min-Duration'), isFalse);
+    });
+  });
+}
+
+Map<String, dynamic> _gameJson(int id, String name) => {
+      'id': id,
+      'name': name,
+      'minplayers': 2,
+      'maxplayers': 4,
+      'maxplaytime': 60,
+      'image': 'http://example.com/$id.jpg',
+      'thumbnail': null,
+      'stats': {'average': 7.5, 'averageweight': 2.5},
+    };


### PR DESCRIPTION
## Summary

- Shelf of Shame page — shows unplayed games from a collection, with permalink support (`/shelf-of-shame/:username`) and sort by plays
- Primary player — persisted across sessions, auto-fetches plays and collection data on set
- Plays service with retry client and per-username caching
- Feature drawer for categorised navigation (Play, Discover, My Games)
- Listing page: responsive columns, plays column with sorting, fixed header alignment on wide views
- Rating badge moves inline when it would overlap the game details panel
- High-contrast switch theming (track outline + thumb)
- Extracted shared `UnplayedOnlyToggle` widget

## Test plan

- [x] `dart format` clean
- [x] `flutter analyze` — no issues
- [x] `flutter test` — 269 tests pass
- [x] Shelf of Shame loads for a user with unplayed games
- [ ] Permalink `/shelf-of-shame/username` hot-loads correctly
- [x] Primary player persists across browser refresh
- [x] Listing columns don't overflow on mobile
- [x] Rating badge moves inline when panel is tall