### PR TITLE
fix: listing page plays/ownership not showing without visiting shelf first

### DIFF
--- a/lib/platform/web_or_tablet/enhanced_list_games_display.dart
+++ b/lib/platform/web_or_tablet/enhanced_list_games_display.dart
@@ -74,12 +74,14 @@ class _GameListBodyState extends State<_GameListBody> with ScreenTools {
   @override
   void initState() {
     super.initState();
+    widget.model.addListener(_rebuild);
     widget.favouritesService.addListener(_rebuild);
     widget.ignoredService.addListener(_rebuild);
   }
 
   @override
   void dispose() {
+    widget.model.removeListener(_rebuild);
     widget.favouritesService.removeListener(_rebuild);
     widget.ignoredService.removeListener(_rebuild);
     super.dispose();


### PR DESCRIPTION
## Summary

- `_GameListBody` was not subscribed to `AppModel` notifications
- Plays and ownership markers only appeared if data loaded before navigating to the listing page
- Added model listener so the widget rebuilds when `loadPlays()` completes

## Test plan

- [x] 269 tests pass
- [x] Navigate directly to listing page — plays/owned markers appear
- [x] No double-rebuild or jank