### PR TITLE
feat: collection ownership dates and permalink/primary-player fixes

### DIFF
--- a/lib/model/bgg_cache.dart
+++ b/lib/model/bgg_cache.dart
@@ -28,6 +28,14 @@ class BggCache {
     }
     _removeIgnoredFromPool();
     if (_remainingPool.isEmpty) {
+      // Drawing without replacement has emptied the pool. Rebuild it from the
+      // full collection so the roll never exhausts the list - the collection
+      // stays stable and we keep selecting from it however many times the user
+      // rolls.
+      _replenishPool();
+    }
+    if (_remainingPool.isEmpty) {
+      // Nothing left even after rebuilding (e.g. every game is ignored).
       return _validatedSticky;
     }
     _stickyRandom = _nextRandom();
@@ -39,6 +47,17 @@ class BggCache {
     var selectedGame = _remainingPool[randomIndex];
     _remainingPool.removeWhere((g) => g.id == selectedGame.id);
     return selectedGame;
+  }
+
+  /// Rebuilds the draw pool from the full collection. When more than one game
+  /// is available, the just-shown game is held back so replenishing at the end
+  /// of a cycle doesn't immediately repeat it.
+  void _replenishPool() {
+    _remainingPool = _buildWeightedPool();
+    final sticky = _stickyRandom;
+    if (sticky != null && _remainingPool.any((g) => g.id != sticky.id)) {
+      _remainingPool.removeWhere((g) => g.id == sticky.id);
+    }
   }
 
   void _removeIgnoredFromPool() {

--- a/lib/model/game.dart
+++ b/lib/model/game.dart
@@ -11,6 +11,10 @@ class Game {
   final double averageRating;
   final double averageWeight;
 
+  /// The date this game entered the owner's collection. Null when the backend
+  /// reported no date or a whitelist omitted the field.
+  final DateTime? lastModified;
+
   Game({
     required this.id,
     required this.name,
@@ -21,6 +25,7 @@ class Game {
     this.thumbnail,
     required this.averageRating,
     required this.averageWeight,
+    this.lastModified,
   });
 
   factory Game.fromJson(Map<String, dynamic> json) {
@@ -34,7 +39,13 @@ class Game {
       thumbnail: json['thumbnail'],
       averageRating: (json['stats']['average'] ?? 0).toDouble(),
       averageWeight: (json['stats']['averageweight'] ?? 0).toDouble(),
+      lastModified: _parseLastModified(json['lastmodified']),
     );
+  }
+
+  static DateTime? _parseLastModified(Object? value) {
+    if (value is! String || value.isEmpty) return null;
+    return DateTime.tryParse(value);
   }
 
   @override

--- a/lib/model/item.dart
+++ b/lib/model/item.dart
@@ -47,6 +47,38 @@ class Item {
     return Item(json['name'], itemType: ItemType.fromJson(json['item_type']));
   }
 
+  /// Encodes this item as a single URL-fragment token. A hotList item is
+  /// wrapped in square brackets (e.g. `[trending]`) so that on reload it is
+  /// restored as a hotList source rather than being mistaken for a BGG
+  /// username - `trending` is a valid username BGG could one day assign.
+  String toUrlToken() => itemType == ItemType.hotList ? '[$name]' : name;
+
+  /// Restores an item from a [toUrlToken] fragment. A bracketed token is a
+  /// hotList source; anything else falls back to name-based auto-detection.
+  ///
+  /// The token is percent-decoded first: browsers encode the square brackets
+  /// as `%5B`/`%5D` in the URL fragment, so a hotList link arrives here as
+  /// `%5Btrending%5D` rather than a literal `[trending]`.
+  factory Item.fromUrlToken(String token) {
+    final decoded = _tryDecode(token);
+    if (decoded.length >= 2 &&
+        decoded.startsWith('[') &&
+        decoded.endsWith(']')) {
+      return Item(decoded.substring(1, decoded.length - 1),
+          itemType: ItemType.hotList);
+    }
+    return Item(decoded);
+  }
+
+  static String _tryDecode(String token) {
+    try {
+      return Uri.decodeComponent(token);
+    } on ArgumentError {
+      // Malformed percent-encoding - fall back to the raw token.
+      return token;
+    }
+  }
+
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||

--- a/lib/model/model.dart
+++ b/lib/model/model.dart
@@ -224,27 +224,43 @@ class AppModel extends ChangeNotifier {
 
   SortableGameField sortGameField = SortableGameField.rating;
 
-  UrlFragmentExtractor _extractor = UrlFragmentExtractor(Uri.base);
+  final UrlFragmentExtractor _extractor;
 
-  AppModel({PreferencesHistoryInterface? preferencesHistory})
-      : _preferencesHistory =
-            preferencesHistory ?? StorageFactory.getPreferencesHistory() {
+  AppModel({
+    PreferencesHistoryInterface? preferencesHistory,
+    UrlFragmentExtractor? urlExtractor,
+  })  : _preferencesHistory =
+            preferencesHistory ?? StorageFactory.getPreferencesHistory(),
+        _extractor = urlExtractor ?? UrlFragmentExtractor(Uri.base) {
     _settings = Settings.defaultSettings();
   }
 
   Future<void> refreshFromUrl() async {
+    await _consumeUrlModel();
+  }
+
+  /// Applies items and settings encoded in the URL fragment, if any, exactly
+  /// once. Safe to call from any entry point (home pages or a deep-linked
+  /// list/random/detail page) and idempotent thereafter.
+  Future<void> _consumeUrlModel() async {
     if (_urlConsumed) return;
-    if (_extractor.containsModel()) {
-      _urlConsumed = true;
-      await replaceItems(_extractor.extractItems());
-      var extractedSettings = _extractor.extractSettings();
-      extractedSettings = _rebuildUrlMechanics(extractedSettings);
-      if (_settings != extractedSettings) {
-        _settings.updateAllSettings(extractedSettings);
-        invalidateCache();
-      }
+    if (!_extractor.containsModel()) return;
+    _urlConsumed = true;
+    await _deferPastCurrentBuild();
+    await replaceItems(_extractor.extractItems());
+    var extractedSettings = _extractor.extractSettings();
+    extractedSettings = _rebuildUrlMechanics(extractedSettings);
+    if (_settings != extractedSettings) {
+      _settings.updateAllSettings(extractedSettings);
+      invalidateCache();
     }
   }
+
+  /// The bootstrap methods run inside a widget build (the home pages call them
+  /// from a Consumer builder), so the notifyListeners() that follows would
+  /// otherwise fire during that build. Yielding to a microtask lets the current
+  /// build complete first.
+  Future<void> _deferPastCurrentBuild() => Future<void>.microtask(() {});
 
   Settings _rebuildUrlMechanics(Settings extractedSettings) {
     final mechanicsSetting =
@@ -273,8 +289,25 @@ class AppModel extends ChangeNotifier {
       return;
     }
     _items = items;
+    _reconcilePrimaryPlayer();
     invalidateCache();
     await updateStore();
+  }
+
+  /// Keeps [primaryPlayer] consistent with the current collection items after
+  /// the item list is swapped wholesale (e.g. following a shared permalink or
+  /// searching a different collection). If the existing primary player is no
+  /// longer among the collections, it falls back to the first collection in
+  /// the new list, or null when none remain. Going through the setter clears
+  /// the stale plays/collection data and reloads for the new player.
+  void _reconcilePrimaryPlayer() {
+    final collections = _items.itemList
+        .where((i) => i.itemType == ItemType.collection)
+        .toList();
+    final stillPresent = _primaryPlayer != null &&
+        collections.any((i) => i.name == _primaryPlayer);
+    if (stillPresent) return;
+    primaryPlayer = collections.isNotEmpty ? collections.first.name : null;
   }
 
   Future<void> replaceSettings(Settings settings) async {
@@ -346,17 +379,28 @@ class AppModel extends ChangeNotifier {
 
   Future<void> loadStoredData() async {
     if (_extractor.containsModel()) {
+      // A shared/deep link encodes the model in the URL fragment. Apply it here
+      // so the parameters survive a hard refresh onto any page, not just the
+      // home pages that separately call refreshFromUrl(). The primary player is
+      // derived from the permalink's collections by replaceItems - the stored
+      // one belongs to a previous session and must not clobber it.
+      await _consumeUrlModel();
       hasLoadedPersistedData = true;
-      _urlConsumed = true;
     } else {
       final store = await _getStore();
       _items = await store.loadItems(AppCommon.maxItemsFromBgg);
       replaceSettings(await store.loadSettings(settings));
       hasLoadedPersistedData = true;
+
+      final prefs = await SharedPreferences.getInstance();
+      _primaryPlayer = prefs.getString('primary_player');
+      // Enforce the invariant that a set collection always has a primary
+      // player: on refresh the stored value may be missing or stale (a
+      // collection removed in a prior session), which would leave no crown
+      // icon. Fall back to the first collection in the list.
+      _reconcilePrimaryPlayer();
     }
 
-    final prefs = await SharedPreferences.getInstance();
-    _primaryPlayer = prefs.getString('primary_player');
     notifyListeners();
 
     if (_primaryPlayer != null) {

--- a/lib/model/settings.dart
+++ b/lib/model/settings.dart
@@ -3,7 +3,8 @@ import 'package:how_many_mobile_meeple/model/setting.dart';
 class Settings {
   static Setting fieldsToReturnFromApi = Setting("fieldsToUse",
       header: "Bgg-Field-Whitelist",
-      value: "id,name,maxplayers,minplayers,maxplaytime,image,thumbnail,stats",
+      value:
+          "id,name,maxplayers,minplayers,maxplaytime,image,thumbnail,stats,lastmodified",
       enabled: true);
 
   static Setting filterNumberOfPlayers =

--- a/lib/platform/web/url_fragment_encoder.dart
+++ b/lib/platform/web/url_fragment_encoder.dart
@@ -4,7 +4,8 @@ import 'package:how_many_mobile_meeple/model/settings.dart';
 class UrlFragmentEncoder {
   static String encode(String name,
       {required Items items, required Settings settings}) {
-    var encodedItems = items.itemList.map((item) => item.name).join("+");
+    var encodedItems =
+        items.itemList.map((item) => item.toUrlToken()).join("+");
     var encodedSettings = settings.changedSettings.values
         .map((setting) => "${setting.name}=${setting.value}")
         .join("&");

--- a/lib/platform/web/url_fragment_extractor.dart
+++ b/lib/platform/web/url_fragment_extractor.dart
@@ -10,8 +10,18 @@ class UrlFragmentExtractor {
 
   UrlFragmentExtractor(Uri uri) {
     this.uri = uri;
-    hasModelData = uri.hasFragment && !Router.routeList.contains(uri.fragment);
+    hasModelData = uri.hasFragment &&
+        !Router.routeList.contains(uri.fragment) &&
+        !_isGameDetailFragment(uri.fragment);
   }
+
+  /// A game detail deep link (e.g. `/game/Gloomhaven/174430`) encodes no
+  /// sources or settings - the trailing segment is a game id, not a collection.
+  /// Treating it as a model would wire that id in as a source, so we exclude it
+  /// and let stored parameters load instead.
+  bool _isGameDetailFragment(String fragment) =>
+      fragment == Router.gameDetailRoute ||
+      fragment.startsWith('${Router.gameDetailRoute}/');
 
   bool containsModel() {
     return hasModelData;
@@ -24,7 +34,7 @@ class UrlFragmentExtractor {
     var potentialEncodedItems = _removePageTypeFromFragment(uri.fragment);
     var itemsFromString = potentialEncodedItems
         .split("+")
-        .map((strItem) => Item(strItem))
+        .map((strItem) => Item.fromUrlToken(strItem))
         .toList();
     return Items(itemsFromString);
   }

--- a/lib/play_log/play_log_page.dart
+++ b/lib/play_log/play_log_page.dart
@@ -190,7 +190,7 @@ class _PlayLogPageState extends State<PlayLogPage> with AppPage {
           const SizedBox(width: 12),
           Expanded(
             child: Text(
-              "You haven't played $name in $months months — "
+              "You haven't played $name in $months months - "
               'time to bring it back to the table?',
               style: TextStyle(
                 color: Theme.of(context).colorScheme.onTertiaryContainer,

--- a/lib/play_log/play_log_service.dart
+++ b/lib/play_log/play_log_service.dart
@@ -6,7 +6,7 @@ import 'play_log_entry.dart';
 /// Stores a chronological history of games the user has played.
 ///
 /// Unlike favourites/ignored (which are sets keyed by game id), the play log
-/// allows the same game to appear many times — one entry per play. Entries are
+/// allows the same game to appear many times - one entry per play. Entries are
 /// persisted to [SharedPreferences] as JSON and always exposed newest-first.
 class PlayLogService extends ChangeNotifier {
   static const String storageKey = 'play_log';

--- a/lib/shelf_of_shame/shelf_of_shame_page.dart
+++ b/lib/shelf_of_shame/shelf_of_shame_page.dart
@@ -226,7 +226,8 @@ class _ShelfOfShamePageState extends State<ShelfOfShamePage>
     final allGames = _fullCollection!;
     final unplayedGames = allGames.gamesByName.values
         .where((game) => model.isUnplayed(game.id))
-        .toList();
+        .toList()
+      ..sort(_worstOffenderFirst);
 
     if (unplayedGames.isEmpty) {
       return Center(
@@ -327,16 +328,99 @@ class _ShelfOfShamePageState extends State<ShelfOfShamePage>
           ),
         ),
         title: Text(game.name),
-        subtitle: Text(
-          '${game.minPlayers}-${game.maxPlayers} players',
-          style: TextStyle(
-              fontSize: 12, color: Theme.of(context).colorScheme.secondary),
-        ),
+        subtitle: _buildTileSubtitle(context, game),
         onTap: () => Navigator.of(context).pushNamed(
             '${r.Router.gameDetailRoute}/${game.name.replaceAll(' ', '+')}/${game.id}'),
       ),
     );
   }
+
+  /// Games owned longest without a play surface first; those missing an
+  /// ownership date sink to the bottom, ordered by name for stability.
+  int _worstOffenderFirst(Game a, Game b) {
+    final da = a.lastModified;
+    final db = b.lastModified;
+    if (da == null && db == null) return a.name.compareTo(b.name);
+    if (da == null) return 1;
+    if (db == null) return -1;
+    return da.compareTo(db);
+  }
+
+  /// Whole years between [date] and today, floored (0 if less than a year).
+  int _yearsSince(DateTime date) {
+    final now = DateTime.now();
+    var years = now.year - date.year;
+    if (now.month < date.month ||
+        (now.month == date.month && now.day < date.day)) {
+      years--;
+    }
+    return years < 0 ? 0 : years;
+  }
+
+  /// A game is a "worst offender" once it has sat unplayed for three-plus years.
+  static const int _worstOffenderYears = 3;
+
+  Widget _buildTileSubtitle(BuildContext context, Game game) {
+    final owned = game.lastModified;
+    final playerLine = _buildPlayerCountLine(context, game);
+
+    if (owned == null) {
+      return playerLine;
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        playerLine,
+        const SizedBox(height: 2),
+        _buildOwnershipLine(context, owned),
+      ],
+    );
+  }
+
+  Widget _buildPlayerCountLine(BuildContext context, Game game) {
+    return Text(
+      '${game.minPlayers}-${game.maxPlayers} players',
+      style: TextStyle(
+          fontSize: 12, color: Theme.of(context).colorScheme.secondary),
+    );
+  }
+
+  Widget _buildOwnershipLine(BuildContext context, DateTime owned) {
+    final years = _yearsSince(owned);
+
+    if (years >= _worstOffenderYears) {
+      return Text(
+        "Dude - $years years owned, still unplayed!",
+        style: TextStyle(
+          fontSize: 12,
+          fontWeight: FontWeight.w600,
+          color: Theme.of(context).colorScheme.error,
+        ),
+      );
+    }
+
+    return Text(
+      _ownershipLabel(owned, years),
+      style: TextStyle(
+          fontSize: 12, color: Theme.of(context).colorScheme.onSurfaceVariant),
+    );
+  }
+
+  String _ownershipLabel(DateTime owned, int years) {
+    final ownedSince = 'Owned since ${_monthYear(owned)}';
+    if (years < 1) return ownedSince;
+    final duration = years == 1 ? '1 year' : '$years years';
+    return '$ownedSince • $duration unplayed';
+  }
+
+  static const List<String> _monthAbbreviations = [
+    'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', //
+    'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+  ];
+
+  String _monthYear(DateTime date) =>
+      '${_monthAbbreviations[date.month - 1]} ${date.year}';
 
   Widget _buildBgStatsPlug(BuildContext context) {
     return Padding(

--- a/mock-api/server.js
+++ b/mock-api/server.js
@@ -13,6 +13,7 @@ const mockGames = {
       minplayers: 1,
       maxplaytime: 120,
       image: 'https://cf.geekdo-images.com/sZYp_3BTDGjh2unaZfZmuA__original/img/pKft1d38Zr88VoM_vk5SbZjtQsk=/0x0/filters:format(jpeg)/pic2437871.jpg',
+      lastmodified: '2018-11-02',
       stats: {
         average: 8.7,
         averageweight: 3.86
@@ -25,6 +26,7 @@ const mockGames = {
       minplayers: 1,
       maxplaytime: 120,
       image: 'https://cf.geekdo-images.com/wg9oOLcsKvDesSUdZQ4rxw__original/img/FS1RE8Ue6nk1pNbPI3l-OSapQGc=/0x0/filters:format(jpeg)/pic3536616.jpg',
+      lastmodified: null,
       stats: {
         average: 8.4,
         averageweight: 3.25
@@ -37,6 +39,7 @@ const mockGames = {
       minplayers: 2,
       maxplaytime: 150,
       image: 'https://cf.geekdo-images.com/bre12PlN4lHLHlh952hQxA__original/img/OsoO8BEgAV0EbiT93wWSIGWfIbY=/0x0/filters:format(jpeg)/pic5375624.jpg',
+      lastmodified: '2024-06-20',
       stats: {
         average: 8.2,
         averageweight: 3.96
@@ -199,6 +202,17 @@ const server = http.createServer((req, res) => {
     return filtered;
   };
 
+  // Mirror the backend's whitelist behaviour for `lastmodified`: emitted by
+  // default, kept when the header lists it, dropped when a header is present
+  // but omits it. Other fields are left untouched by this mock.
+  const applyLastModifiedWhitelist = (games, headers) => {
+    const whitelist = headers['bgg-field-whitelist'];
+    if (whitelist === undefined) return games;
+    const fields = whitelist.split(',').map(f => f.trim());
+    if (fields.includes('lastmodified')) return games;
+    return games.map(({ lastmodified, ...rest }) => rest);
+  };
+
   // Handle collection endpoint: /collection/username
   const collectionMatch = path.match(/^\/collection\/(.+)$/);
   if (collectionMatch) {
@@ -207,6 +221,7 @@ const server = http.createServer((req, res) => {
 
     // Apply filters
     games = filterGames(games, req.headers);
+    games = applyLastModifiedWhitelist(games, req.headers);
 
     console.log(`  → Returning ${games.length} games after filtering`);
 

--- a/test/guided_flow/step4_game_style_test.dart
+++ b/test/guided_flow/step4_game_style_test.dart
@@ -113,7 +113,7 @@ void main() {
 
       await tester.pumpWidget(_buildTestWidget(model));
 
-      // Hand Management is in 'Core Gameplay' — visible above fold
+      // Hand Management is in 'Core Gameplay' - visible above fold
       await tester.tap(find.text('Hand Management'));
       await tester.pump();
 

--- a/test/model/app_model_build_notify_test.dart
+++ b/test/model/app_model_build_notify_test.dart
@@ -1,0 +1,67 @@
+@Tags(['widget'])
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:how_many_mobile_meeple/api/http_retry_client.dart';
+import 'package:how_many_mobile_meeple/api/plays_service.dart';
+import 'package:how_many_mobile_meeple/model/model.dart';
+import 'package:how_many_mobile_meeple/platform/web/url_fragment_extractor.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import '../helpers/mock_api_client.dart';
+
+AppModel _modelForFragment(String fragment) {
+  final uri = Uri(fragment: fragment);
+  return AppModel(urlExtractor: UrlFragmentExtractor(uri));
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    PlaysService.clearCache();
+    HttpRetryClient.setDelayFunction((_) => Future.value());
+    HttpRetryClient.setTestClient(mockApiClient());
+  });
+
+  tearDown(() {
+    HttpRetryClient.resetTestClient();
+    HttpRetryClient.resetDelayFunction();
+    PlaysService.clearCache();
+  });
+
+  // The home pages call loadStoredData()/refreshFromUrl() from inside a
+  // Consumer<AppModel> builder. When the URL encodes a model, applying it must
+  // not fire notifyListeners() synchronously during that build - doing so
+  // throws "setState() or markNeedsBuild() called during build".
+  testWidgets(
+      'consuming a URL model from inside build does not notify during build',
+      (tester) async {
+    final model = _modelForFragment('/random/%5Btrending%5D');
+
+    await tester.pumpWidget(
+      ChangeNotifierProvider<AppModel>.value(
+        value: model,
+        child: MaterialApp(
+          home: Consumer<AppModel>(
+            builder: (context, m, child) {
+              if (!m.hasLoadedPersistedData) {
+                m.loadStoredData();
+                m.refreshFromUrl();
+              }
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // No FlutterError was thrown, and the model still bootstrapped correctly.
+    expect(tester.takeException(), isNull);
+    expect(model.hasLoadedPersistedData, isTrue);
+    expect(model.items.itemList.map((i) => i.name), contains('trending'));
+  });
+}

--- a/test/model/app_model_deep_link_test.dart
+++ b/test/model/app_model_deep_link_test.dart
@@ -1,0 +1,110 @@
+@Tags(['unit'])
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:how_many_mobile_meeple/api/http_retry_client.dart';
+import 'package:how_many_mobile_meeple/api/plays_service.dart';
+import 'package:how_many_mobile_meeple/model/model.dart';
+import 'package:how_many_mobile_meeple/model/settings.dart';
+import 'package:how_many_mobile_meeple/platform/web/url_fragment_extractor.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import '../helpers/mock_api_client.dart';
+
+AppModel _modelForFragment(String fragment) {
+  final uri = Uri(fragment: fragment);
+  return AppModel(urlExtractor: UrlFragmentExtractor(uri));
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    PlaysService.clearCache();
+    HttpRetryClient.setDelayFunction((_) => Future.value());
+    HttpRetryClient.setTestClient(mockApiClient());
+  });
+
+  tearDown(() {
+    HttpRetryClient.resetTestClient();
+    HttpRetryClient.resetDelayFunction();
+    PlaysService.clearCache();
+  });
+
+  group('deep-link bootstrap (hard refresh onto a non-home page)', () {
+    test('loadStoredData applies URL items when the fragment encodes a model',
+        () async {
+      // A hard refresh onto /random with a shared collection in the fragment.
+      final model = _modelForFragment('/random/deeplinkuser');
+
+      await model.loadStoredData();
+
+      expect(model.hasLoadedPersistedData, true);
+      expect(model.items.itemList.map((i) => i.name), contains('deeplinkuser'));
+    });
+
+    test('loadStoredData applies URL settings when present in the fragment',
+        () async {
+      final model = _modelForFragment('/list/deeplinkuser?numberOfPlayers=6');
+
+      await model.loadStoredData();
+
+      final setting =
+          model.settings.setting(Settings.filterNumberOfPlayers.name);
+      expect(setting.value.toString(), '6');
+    });
+
+    test('refreshFromUrl after loadStoredData does not double-apply the model',
+        () async {
+      final model = _modelForFragment('/random/deeplinkuser');
+
+      await model.loadStoredData();
+      // Home pages also call refreshFromUrl(); it must be a no-op once consumed.
+      await model.refreshFromUrl();
+
+      final userCount =
+          model.items.itemList.where((i) => i.name == 'deeplinkuser').length;
+      expect(userCount, 1);
+    });
+
+    test(
+        'game detail deep link does not wire the game id in as a source and '
+        'loads stored parameters instead', () async {
+      // Stored collection from a previous visit.
+      SharedPreferences.setMockInitialValues({
+        'primary_player': 'storeduser',
+        'bgg-item-0': '{"name":"storeduser","item_type":{"name":"collection"}}',
+      });
+
+      // Hard refresh straight onto a game page.
+      final model = _modelForFragment('/game/Gloomhaven/174430');
+
+      await model.loadStoredData();
+
+      final names = model.items.itemList.map((i) => i.name).toList();
+      expect(names, isNot(contains('174430')),
+          reason: 'the game id must not become a source');
+      expect(names, contains('storeduser'),
+          reason: 'stored parameters should load when no URL model is present');
+    });
+
+    test(
+        'permalink to a different collection sets the primary player from the '
+        'link, not the stored one', () async {
+      // A previous session left a stored primary player behind.
+      SharedPreferences.setMockInitialValues({
+        'primary_player': 'storeduser',
+        'bgg-item-0': '{"name":"storeduser","item_type":{"name":"collection"}}',
+      });
+
+      // Following a shared permalink for a different collection.
+      final model = _modelForFragment('/shelf-of-shame/linkeduser');
+
+      await model.loadStoredData();
+
+      expect(model.primaryPlayer, 'linkeduser',
+          reason: 'the permalink collection must drive the primary player so '
+              'shelf of shame / play history do not stick to the old one');
+    });
+  });
+}

--- a/test/model/app_model_plays_test.dart
+++ b/test/model/app_model_plays_test.dart
@@ -198,7 +198,7 @@ void main() {
 
       SharedPreferences.setMockInitialValues({
         'primary_player': 'storeduser',
-        'item_0': '{"name":"storeduser","item_type":{"name":"collection"}}',
+        'bgg-item-0': '{"name":"storeduser","item_type":{"name":"collection"}}',
       });
 
       final model = AppModel();

--- a/test/model/app_model_primary_player_test.dart
+++ b/test/model/app_model_primary_player_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:how_many_mobile_meeple/api/http_retry_client.dart';
 import 'package:how_many_mobile_meeple/api/plays_service.dart';
 import 'package:how_many_mobile_meeple/model/item.dart';
+import 'package:how_many_mobile_meeple/model/items.dart';
 import 'package:how_many_mobile_meeple/model/model.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import '../helpers/mock_api_client.dart';
@@ -119,13 +120,43 @@ void main() {
     test('loads persisted primary player on loadStoredData', () async {
       SharedPreferences.setMockInitialValues({
         'primary_player': 'saveduser',
-        'item_0': '{"name":"saveduser","item_type":{"name":"collection"}}',
+        'bgg-item-0': '{"name":"saveduser","item_type":{"name":"collection"}}',
       });
 
       final model = AppModel();
       await model.loadStoredData();
 
       expect(model.primaryPlayer, 'saveduser');
+    });
+
+    test(
+        'sets primary player to first collection on refresh when stored value '
+        'is missing', () async {
+      // A stored collection with no persisted primary player (e.g. cleared in a
+      // prior session) must still surface a primary player on refresh.
+      SharedPreferences.setMockInitialValues({
+        'bgg-item-0': '{"name":"firstuser","item_type":{"name":"collection"}}',
+        'bgg-item-1': '{"name":"seconduser","item_type":{"name":"collection"}}',
+      });
+
+      final model = AppModel();
+      await model.loadStoredData();
+
+      expect(model.primaryPlayer, 'firstuser');
+    });
+
+    test(
+        'resets primary player to first collection on refresh when stored '
+        'value is no longer in the list', () async {
+      SharedPreferences.setMockInitialValues({
+        'primary_player': 'goneuser',
+        'bgg-item-0': '{"name":"firstuser","item_type":{"name":"collection"}}',
+      });
+
+      final model = AppModel();
+      await model.loadStoredData();
+
+      expect(model.primaryPlayer, 'firstuser');
     });
 
     test('notifies listeners when primary player changes', () async {
@@ -151,6 +182,62 @@ void main() {
       model.primaryPlayer = 'teqqles';
 
       expect(notifyCount, 0);
+    });
+  });
+
+  group('AppModel.replaceItems primary player reconciliation', () {
+    test(
+        'switches primary player when items are replaced with a new collection',
+        () async {
+      final model = AppModel();
+      await model.addItem(Item('olduser'));
+      expect(model.primaryPlayer, 'olduser');
+
+      await model.replaceItems(Items([Item('newuser')]));
+
+      expect(model.primaryPlayer, 'newuser');
+    });
+
+    test('keeps primary player when it is still among the replaced items',
+        () async {
+      final model = AppModel();
+      await model.addItem(Item('teqqles'));
+
+      await model.replaceItems(Items([Item('teqqles'), Item('otheruser')]));
+
+      expect(model.primaryPlayer, 'teqqles');
+    });
+
+    test('clears primary player when no collections remain after replace',
+        () async {
+      final model = AppModel();
+      await model.addItem(Item('olduser'));
+
+      await model
+          .replaceItems(Items([Item('hot', itemType: ItemType.hotList)]));
+
+      expect(model.primaryPlayer, isNull);
+    });
+
+    test('replacing collection reloads plays for the new primary player',
+        () async {
+      final capturedPaths = <String>[];
+      HttpRetryClient.setTestClient(
+          mockApiClient(onRequest: (r) => capturedPaths.add(r.url.path)));
+
+      final model = AppModel();
+      await model.addItem(Item('olduser'));
+      await Future.delayed(Duration.zero);
+      capturedPaths.clear();
+
+      await model.replaceItems(Items([Item('newuser')]));
+      await Future.delayed(Duration.zero);
+
+      // Switching collections must fetch plays/collection for the new player so
+      // shelf of shame / play history don't stick to the old collection.
+      expect(capturedPaths, contains('/plays/newuser'));
+      expect(capturedPaths, contains('/collection/newuser'));
+      expect(capturedPaths, isNot(contains('/plays/olduser')));
     });
   });
 }

--- a/test/model/bgg_cache_test.dart
+++ b/test/model/bgg_cache_test.dart
@@ -55,7 +55,7 @@ main() {
 
       expect(cache.isStale(), false);
 
-      // 4 minutes later — still fresh
+      // 4 minutes later - still fresh
       currentTime = baseTime.add(Duration(minutes: 4));
       expect(cache.isStale(), false);
     });
@@ -65,11 +65,11 @@ main() {
       var currentTime = baseTime;
       final cache = BggCache(games, 5, clock: () => currentTime);
 
-      // 5 minutes later — at boundary
+      // 5 minutes later - at boundary
       currentTime = baseTime.add(Duration(minutes: 5));
       expect(cache.isStale(), false);
 
-      // 5 minutes + 1 second — past boundary
+      // 5 minutes + 1 second - past boundary
       currentTime = baseTime.add(Duration(minutes: 5, seconds: 1));
       expect(cache.isStale(), true);
     });
@@ -164,6 +164,39 @@ main() {
       var cache = BggCache(games, duration);
       var first = cache.lastRandom;
       expect(cache.lastRandom, first);
+    });
+  });
+  group('random does not exhaust the collection', () {
+    test('keeps returning games when rolled far more times than the pool size',
+        () {
+      var cache = BggCache(games, duration);
+
+      // Two games in the pool; roll many times over. The pool must replenish
+      // rather than run dry and start returning null.
+      for (var i = 0; i < 50; i++) {
+        expect(cache.random, TypeMatcher<Game>(),
+            reason: 'roll $i should still yield a game');
+      }
+    });
+
+    test('replenished pool still only ever selects games from the collection',
+        () {
+      var cache = BggCache(games, duration);
+      final validIds = {game1.id, game2.id};
+
+      for (var i = 0; i < 50; i++) {
+        final game = cache.random!;
+        expect(validIds.contains(game.id), true);
+      }
+    });
+
+    test('single-game collection keeps returning that game on repeated rolls',
+        () {
+      var cache = BggCache(Games(gamesByName: {game1.name: game1}), duration);
+
+      for (var i = 0; i < 10; i++) {
+        expect(cache.random, game1);
+      }
     });
   });
 }

--- a/test/model/game_test.dart
+++ b/test/model/game_test.dart
@@ -1,0 +1,61 @@
+@Tags(['unit'])
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:how_many_mobile_meeple/model/game.dart';
+
+Map<String, dynamic> _gameJson({Object? lastmodified = _absent}) => {
+      'id': 174430,
+      'name': 'Gloomhaven',
+      'minplayers': 1,
+      'maxplayers': 4,
+      'maxplaytime': 120,
+      'image': 'http://example.com/gloom.jpg',
+      'thumbnail': 'http://example.com/gloom_t.jpg',
+      'stats': {'average': 8.6, 'averageweight': 3.9},
+      if (!identical(lastmodified, _absent)) 'lastmodified': lastmodified,
+    };
+
+const Object _absent = Object();
+
+void main() {
+  group('Game.fromJson lastModified', () {
+    test('parses a YYYY-MM-DD string into a DateTime', () {
+      final game = Game.fromJson(_gameJson(lastmodified: '2022-03-15'));
+
+      expect(game.lastModified, DateTime(2022, 3, 15));
+    });
+
+    test('is null when the field is explicitly null', () {
+      final game = Game.fromJson(_gameJson(lastmodified: null));
+
+      expect(game.lastModified, isNull);
+    });
+
+    test('is null when the field is absent (whitelist omitted it)', () {
+      final game = Game.fromJson(_gameJson());
+
+      expect(game.lastModified, isNull);
+    });
+
+    test('is null when the field is a blank string', () {
+      final game = Game.fromJson(_gameJson(lastmodified: ''));
+
+      expect(game.lastModified, isNull);
+    });
+
+    test('is null for an unparseable date', () {
+      final game = Game.fromJson(_gameJson(lastmodified: 'not-a-date'));
+
+      expect(game.lastModified, isNull);
+    });
+
+    test('parses the other fields alongside lastModified', () {
+      final game = Game.fromJson(_gameJson(lastmodified: '2022-03-15'));
+
+      expect(game.id, 174430);
+      expect(game.name, 'Gloomhaven');
+      expect(game.averageRating, 8.6);
+    });
+  });
+}

--- a/test/model/item_test.dart
+++ b/test/model/item_test.dart
@@ -90,6 +90,61 @@ void main() {
     });
   });
 
+  group('Item URL token round-trip', () {
+    test('collection encodes as its plain name', () {
+      var item = Item('testuser', itemType: ItemType.collection);
+      expect(item.toUrlToken(), 'testuser');
+    });
+
+    test('geekList encodes as its plain name', () {
+      var item = Item('12345', itemType: ItemType.geekList);
+      expect(item.toUrlToken(), '12345');
+    });
+
+    test('hotList encodes wrapped in square brackets', () {
+      var item = Item('trending', itemType: ItemType.hotList);
+      expect(item.toUrlToken(), '[trending]');
+    });
+
+    test('bracketed token restores as a hotList item', () {
+      var item = Item.fromUrlToken('[trending]');
+      expect(item.name, 'trending');
+      expect(item.itemType, ItemType.hotList);
+    });
+
+    test('hotList survives a full round-trip', () {
+      var original = Item('trending', itemType: ItemType.hotList);
+      var restored = Item.fromUrlToken(original.toUrlToken());
+      expect(restored, original);
+      expect(restored.itemType, ItemType.hotList);
+    });
+
+    test('plain username token restores as a collection', () {
+      var item = Item.fromUrlToken('trending');
+      expect(item.name, 'trending');
+      expect(item.itemType, ItemType.collection);
+    });
+
+    test('numeric token restores as a geekList', () {
+      var item = Item.fromUrlToken('12345');
+      expect(item.itemType, ItemType.geekList);
+    });
+
+    test('percent-encoded bracketed token restores as a hotList item', () {
+      // Browsers encode the brackets in the URL fragment, so the token arrives
+      // as %5Btrending%5D rather than a literal [trending].
+      var item = Item.fromUrlToken('%5Btrending%5D');
+      expect(item.name, 'trending');
+      expect(item.itemType, ItemType.hotList);
+    });
+
+    test('malformed percent-encoding falls back to the raw token', () {
+      var item = Item.fromUrlToken('%ZZnotvalid');
+      expect(item.name, '%ZZnotvalid');
+      expect(item.itemType, ItemType.collection);
+    });
+  });
+
   group('Item equality', () {
     test('items with same name and type are equal', () {
       var item1 = Item('test', itemType: ItemType.collection);

--- a/test/platform/web/url_fragment_encoder_test.dart
+++ b/test/platform/web/url_fragment_encoder_test.dart
@@ -124,5 +124,18 @@ main() {
           items: mockItems, settings: mockSettings);
       expect(encodedName, expectedEncodedName);
     });
+
+    test('encodes a hotList item wrapped in square brackets', () {
+      final mockItems = MockItems();
+      final mockSettings = MockSettings();
+
+      when(mockItems.itemList)
+          .thenReturn([Item('trending', itemType: ItemType.hotList)]);
+      when(mockSettings.changedSettings).thenReturn({});
+      var expectedEncodedName = expectedName + '/[trending]';
+      var encodedName = UrlFragmentEncoder.encode(expectedName,
+          items: mockItems, settings: mockSettings);
+      expect(encodedName, expectedEncodedName);
+    });
   });
 }

--- a/test/platform/web/url_fragment_extractor_test.dart
+++ b/test/platform/web/url_fragment_extractor_test.dart
@@ -38,6 +38,24 @@ main() {
       var extractor = UrlFragmentExtractor(mockUri);
       expect(extractor.containsModel(), false);
     });
+
+    test('returns false for a game detail deep link', () {
+      // The trailing segment is a game id, not a source, so this fragment
+      // encodes no model - stored parameters should load instead.
+      final mockUri = MockUri();
+      when(mockUri.hasFragment).thenReturn(true);
+      when(mockUri.fragment).thenReturn('/game/Gloomhaven/174430');
+      var extractor = UrlFragmentExtractor(mockUri);
+      expect(extractor.containsModel(), false);
+    });
+
+    test('returns false for the bare game route', () {
+      final mockUri = MockUri();
+      when(mockUri.hasFragment).thenReturn(true);
+      when(mockUri.fragment).thenReturn('/game');
+      var extractor = UrlFragmentExtractor(mockUri);
+      expect(extractor.containsModel(), false);
+    });
   });
 
   var expectedItems =
@@ -62,6 +80,49 @@ main() {
 
       var extractor = UrlFragmentExtractor(mockUri);
       expect(extractor.extractItems(), expectedItems);
+    });
+
+    test('restores a bracketed hotList token as a hotList source', () {
+      final mockUri = MockUri();
+
+      when(mockUri.hasFragment).thenReturn(true);
+      when(mockUri.fragment).thenReturn("/random/[trending]");
+
+      var extractor = UrlFragmentExtractor(mockUri);
+      final items = extractor.extractItems();
+      expect(items.itemList.length, 1);
+      expect(items.itemList.first.name, 'trending');
+      expect(items.itemList.first.itemType, ItemType.hotList);
+    });
+
+    test('restores a percent-encoded hotList token as a hotList source', () {
+      // The browser encodes the brackets, so the real fragment looks like this.
+      final mockUri = MockUri();
+
+      when(mockUri.hasFragment).thenReturn(true);
+      when(mockUri.fragment).thenReturn("/random/%5Btrending%5D");
+
+      var extractor = UrlFragmentExtractor(mockUri);
+      final items = extractor.extractItems();
+      expect(items.itemList.length, 1);
+      expect(items.itemList.first.name, 'trending');
+      expect(items.itemList.first.itemType, ItemType.hotList);
+    });
+
+    test('restores a mix of hotList and collection tokens', () {
+      final mockUri = MockUri();
+
+      when(mockUri.hasFragment).thenReturn(true);
+      when(mockUri.fragment).thenReturn("/list/[trending]+teqqles");
+
+      var extractor = UrlFragmentExtractor(mockUri);
+      expect(
+        extractor.extractItems(),
+        Items([
+          Item('trending', itemType: ItemType.hotList),
+          Item('teqqles'),
+        ]),
+      );
     });
 
     test('ignores query parameters', () {

--- a/test/shelf_of_shame/shelf_of_shame_page_test.dart
+++ b/test/shelf_of_shame/shelf_of_shame_page_test.dart
@@ -262,10 +262,77 @@ void main() {
       expect(capturedHeaders!.containsKey('Bgg-Filter-Player-Count'), isFalse);
       expect(capturedHeaders!.containsKey('Bgg-Filter-Min-Duration'), isFalse);
     });
+
+    testWidgets('shows ownership date when lastmodified is recent',
+        (tester) async {
+      // Recent enough (under the 3-year threshold) to show the date line
+      // rather than the worst-offender call-out. Pick a fixed month/day well
+      // clear of "today" so the "Mar" label is stable regardless of run date.
+      final recentYear = DateTime.now().year - 1;
+      HttpRetryClient.setTestClient(mockApiClient(
+        collection: [
+          _gameJson(1, 'Catan', lastmodified: '$recentYear-03-15'),
+        ],
+        plays: [
+          {'game_id': 1, 'game_name': 'Catan', 'total_plays': 0},
+        ],
+      ));
+
+      final model = AppModel();
+      await model.addItem(Item('testuser'));
+
+      await tester.pumpWidget(_buildTestApp(model));
+      await tester.pumpAndSettle();
+
+      expect(
+          find.textContaining('Owned since Mar $recentYear'), findsOneWidget);
+    });
+
+    testWidgets('shows worst-offender call-out for long-owned unplayed games',
+        (tester) async {
+      HttpRetryClient.setTestClient(mockApiClient(
+        collection: [
+          _gameJson(1, 'Gloomhaven', lastmodified: '2015-01-01'),
+        ],
+        plays: [
+          {'game_id': 1, 'game_name': 'Gloomhaven', 'total_plays': 0},
+        ],
+      ));
+
+      final model = AppModel();
+      await model.addItem(Item('testuser'));
+
+      await tester.pumpWidget(_buildTestApp(model));
+      await tester.pumpAndSettle();
+
+      expect(
+          find.textContaining('years owned, still unplayed'), findsOneWidget);
+    });
+
+    testWidgets('shows no date line when lastmodified is null', (tester) async {
+      HttpRetryClient.setTestClient(mockApiClient(
+        collection: [
+          _gameJson(1, 'Azul', lastmodified: null),
+        ],
+        plays: [
+          {'game_id': 1, 'game_name': 'Azul', 'total_plays': 0},
+        ],
+      ));
+
+      final model = AppModel();
+      await model.addItem(Item('testuser'));
+
+      await tester.pumpWidget(_buildTestApp(model));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Azul'), findsOneWidget);
+      expect(find.textContaining('Owned since'), findsNothing);
+      expect(find.textContaining('unplayed!'), findsNothing);
+    });
   });
 }
 
-Map<String, dynamic> _gameJson(int id, String name) => {
+Map<String, dynamic> _gameJson(int id, String name, {String? lastmodified}) => {
       'id': id,
       'name': name,
       'minplayers': 2,
@@ -274,4 +341,5 @@ Map<String, dynamic> _gameJson(int id, String name) => {
       'image': 'http://example.com/$id.jpg',
       'thumbnail': null,
       'stats': {'average': 7.5, 'averageweight': 2.5},
+      'lastmodified': lastmodified,
     };


### PR DESCRIPTION
## Summary

Adds collection ownership dates to the shelf of shame and fixes a cluster of permalink, primary-player, and random-roll bugs surfaced while wiring it up.

## Changes

**Ownership date (`lastmodified`)**
- Parse the backend's `lastmodified` field into `Game` as a nullable `DateTime` and add it to the field whitelist so it is returned.
- Shelf of shame sorts games owned longest-unplayed first, shows an "Owned since" line with years unplayed, and flags games owned three or more years as worst offenders. Games with no date show no date line.
- Mock API emits `lastmodified` and honours the whitelist for it.

**Random roll**
- The draw pool removed each selected game and never refilled, so rolling eventually hit the exhausted state. It now replenishes from the full collection when empty, holding back the just-shown game to avoid an immediate repeat.

**Permalinks and primary player**
- Hard refresh onto a list/random/detail page dropped all parameters; the URL model is now applied in `loadStoredData` so it survives a refresh onto any page.
- The game detail route is excluded from model extraction, so a game id is no longer wired in as a source.
- The primary player is reconciled whenever the item list is replaced, and any set collection is guaranteed a primary player (defaulting to the first collection), so shelf of shame and play history follow the current collection instead of a stale one.
- A hotList source is encoded as a bracketed token and item tokens are percent-decoded on the way back, so `trending` survives a shared link instead of loading as a username.
- Deferred the bootstrap `notifyListeners` past the current build to avoid a setState-during-build error when a home page consumes a URL model.

## Testing

`dart format` clean, `flutter analyze` clean, full suite of 487 tests passing.
